### PR TITLE
Replace `Result` with `unwrap()`

### DIFF
--- a/rust/src/macros.rs
+++ b/rust/src/macros.rs
@@ -59,7 +59,6 @@ macro_rules! pjdfs_test {
         $crate::test::Test {
             name: stringify!($test),
             fun: $test,
-            file_system: None,
             require_root: false,
         }
     };
@@ -68,7 +67,6 @@ macro_rules! pjdfs_test {
         $crate::test::Test {
             name: stringify!($test),
             fun: $test,
-            file_system: Some($file_system),
             require_root: false,
         }
     };
@@ -77,7 +75,6 @@ macro_rules! pjdfs_test {
         $crate::test::Test {
             name: stringify!($test),
             fun: $test,
-            file_system: None,
             require_root: $require_root,
         }
     };
@@ -86,7 +83,6 @@ macro_rules! pjdfs_test {
         $crate::test::Test {
             name: stringify!($test),
             fun: $test,
-            file_system: Some($file_system),
             require_root: $require_root,
         }
     };

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,8 +1,14 @@
-use std::io::{stdout, Write};
+use std::{
+    io::{stdout, Write},
+    panic::{catch_unwind, set_hook, AssertUnwindSafe},
+};
 
 use pjdfs_tests::{pjdfs_main, test::TestContext, tests::chmod};
 
 fn main() -> anyhow::Result<()> {
+    //TODO: We should use panic info
+    set_hook(Box::new(|ctx| {}));
+
     for group in [chmod::tests] {
         for test_case in group.test_cases.iter() {
             for test in test_case.tests {
@@ -12,9 +18,17 @@ fn main() -> anyhow::Result<()> {
                 );
                 stdout().lock().flush()?;
                 let mut context = TestContext::new();
-                match (test.fun)(&mut context) {
+                //TODO: AssertUnwindSafe should be used with caution
+                let mut ctx_wrapper = AssertUnwindSafe(&mut context);
+                match catch_unwind(move || {
+                    (test.fun)(&mut ctx_wrapper);
+                }) {
                     Ok(_) => println!("success"),
-                    Err(e) => return Err(anyhow::anyhow!("{}", e)),
+                    Err(e) => {
+                        if let Ok(e) = e.downcast::<String>() {
+                            return Err(anyhow::anyhow!("{}", e));
+                        }
+                    }
                 }
             }
         }

--- a/rust/src/tests/chmod/errno.rs
+++ b/rust/src/tests/chmod/errno.rs
@@ -3,19 +3,14 @@ use nix::{
     sys::stat::{stat, Mode},
 };
 
-use crate::{
-    pjdfs_test_case,
-    runner::context::FileType,
-    test::{TestContext, TestResult},
-    test_assert, test_assert_eq,
-};
+use crate::{pjdfs_test_case, runner::context::FileType, test::TestContext};
 
 use super::chmod;
 
 pjdfs_test_case!(errno, { test: test_enotdir, require_root: true }, { test: test_enametoolong });
 
 /// Returns ENOTDIR if a component of the path prefix is not a directory
-fn test_enotdir(ctx: &mut TestContext) -> TestResult {
+fn test_enotdir(ctx: &mut TestContext) {
     for f_type in [
         FileType::Regular,
         FileType::Fifo,
@@ -23,29 +18,25 @@ fn test_enotdir(ctx: &mut TestContext) -> TestResult {
         FileType::Char,
         FileType::Socket,
     ] {
-        let not_dir = ctx.create(f_type)?;
+        let not_dir = ctx.create(f_type).unwrap();
         let fake_path = not_dir.join("test");
         let res = chmod(&fake_path, Mode::from_bits_truncate(0o0644));
-        test_assert!(res.is_err());
-        test_assert_eq!(res.unwrap_err(), Errno::ENOTDIR);
+        assert!(res.is_err());
+        assert_eq!(res.unwrap_err(), Errno::ENOTDIR);
     }
-
-    Ok(())
 }
 
 /// chmod returns ENAMETOOLONG if a component of a pathname exceeded {NAME_MAX} characters
-fn test_enametoolong(ctx: &mut TestContext) -> TestResult {
-    let path = ctx.create_max(FileType::Regular)?;
+fn test_enametoolong(ctx: &mut TestContext) {
+    let path = ctx.create_max(FileType::Regular).unwrap();
     let expected_mode = 0o620;
-    chmod(&path, Mode::from_bits_truncate(expected_mode))?;
-    let actual_mode = stat(&path)?.st_mode;
-    test_assert_eq!(actual_mode & 0o777, expected_mode);
+    chmod(&path, Mode::from_bits_truncate(expected_mode)).unwrap();
+    let actual_mode = stat(&path).unwrap().st_mode;
+    assert_eq!(actual_mode & 0o777, expected_mode);
 
     let mut too_long_path = path.clone();
     too_long_path.set_extension("x");
     let res = chmod(&too_long_path, Mode::from_bits_truncate(0o0620));
-    test_assert!(res.is_err());
-    test_assert_eq!(res.unwrap_err(), Errno::ENAMETOOLONG);
-
-    Ok(())
+    assert!(res.is_err());
+    assert_eq!(res.unwrap_err(), Errno::ENAMETOOLONG);
 }

--- a/rust/src/tests/chmod/permission.rs
+++ b/rust/src/tests/chmod/permission.rs
@@ -1,12 +1,6 @@
 use std::{thread::sleep, time::Duration};
 
-use crate::{
-    pjdfs_test_case,
-    runner::context::FileType,
-    test::{TestContext, TestResult},
-    test_assert, test_assert_eq,
-    tests::chmod::chmod,
-};
+use crate::{pjdfs_test_case, runner::context::FileType, test::TestContext, tests::chmod::chmod};
 use nix::{
     sys::stat::{lstat, mode_t, stat, Mode},
     unistd::{chown, Gid, Uid},
@@ -24,100 +18,89 @@ pjdfs_test_case!(
 const FILE_PERMS: mode_t = 0o777;
 
 // chmod/00.t:L24
-fn test_change_perm(ctx: &mut TestContext) -> TestResult {
+fn test_change_perm(ctx: &mut TestContext) {
     for f_type in FileType::iter().filter(|ft| *ft != FileType::Symlink(None)) {
-        let path = ctx.create(f_type)?;
+        let path = ctx.create(f_type).unwrap();
         let expected_mode = Mode::from_bits_truncate(0o111);
 
-        chmod(&path, expected_mode)?;
+        chmod(&path, expected_mode).unwrap();
 
-        let actual_mode = stat(&path)?.st_mode;
+        let actual_mode = stat(&path).unwrap().st_mode;
 
-        test_assert_eq!(actual_mode & FILE_PERMS, expected_mode.bits());
+        assert_eq!(actual_mode & FILE_PERMS, expected_mode.bits());
 
         // We test if it applies through symlinks
-        let symlink_path = ctx.create(FileType::Symlink(Some(path.clone())))?;
-        let link_mode = lstat(&symlink_path)?.st_mode;
+        let symlink_path = ctx.create(FileType::Symlink(Some(path.clone()))).unwrap();
+        let link_mode = lstat(&symlink_path).unwrap().st_mode;
         let expected_mode = Mode::from_bits_truncate(0o222);
 
-        chmod(&symlink_path, expected_mode)?;
+        chmod(&symlink_path, expected_mode).unwrap();
 
-        let actual_mode = stat(&path)?.st_mode;
-        let actual_sym_mode = stat(&symlink_path)?.st_mode;
-        test_assert_eq!(actual_mode & FILE_PERMS, expected_mode.bits());
-        test_assert_eq!(actual_sym_mode & FILE_PERMS, expected_mode.bits());
+        let actual_mode = stat(&path).unwrap().st_mode;
+        let actual_sym_mode = stat(&symlink_path).unwrap().st_mode;
+        assert_eq!(actual_mode & FILE_PERMS, expected_mode.bits());
+        assert_eq!(actual_sym_mode & FILE_PERMS, expected_mode.bits());
 
-        let actual_link_mode = lstat(&symlink_path)?.st_mode;
-        test_assert_eq!(link_mode & FILE_PERMS, actual_link_mode & FILE_PERMS);
+        let actual_link_mode = lstat(&symlink_path).unwrap().st_mode;
+        assert_eq!(link_mode & FILE_PERMS, actual_link_mode & FILE_PERMS);
     }
-
-    Ok(())
 }
 
 // chmod/00.t:L58
-fn test_ctime(ctx: &mut TestContext) -> TestResult {
+fn test_ctime(ctx: &mut TestContext) {
     for f_type in FileType::iter().filter(|ft| *ft != FileType::Symlink(None)) {
-        let path = ctx.create(f_type)?;
-        let ctime_before = stat(&path)?.st_ctime;
+        let path = ctx.create(f_type).unwrap();
+        let ctime_before = stat(&path).unwrap().st_ctime;
 
         sleep(Duration::from_secs(1));
 
-        chmod(&path, Mode::from_bits_truncate(0o111))?;
+        chmod(&path, Mode::from_bits_truncate(0o111)).unwrap();
 
-        let ctime_after = stat(&path)?.st_ctime;
-        test_assert!(ctime_after > ctime_before);
+        let ctime_after = stat(&path).unwrap().st_ctime;
+        assert!(ctime_after > ctime_before);
     }
-
-    Ok(())
 }
 
 // chmod/00.t:L89
-fn test_failed_chmod_unchanged_ctime(ctx: &mut TestContext) -> TestResult {
+fn test_failed_chmod_unchanged_ctime(ctx: &mut TestContext) {
     for f_type in FileType::iter().filter(|ft| *ft != FileType::Symlink(None)) {
-        let path = ctx.create(f_type)?;
-        let ctime_before = stat(&path)?.st_ctime;
+        let path = ctx.create(f_type).unwrap();
+        let ctime_before = stat(&path).unwrap().st_ctime;
 
         sleep(Duration::from_secs(1));
 
         ctx.as_user(Some(Uid::from_raw(65534)), None, || {
-            test_assert!(chmod(&path, Mode::from_bits_truncate(0o111)).is_err());
-            Ok(())
-        })?;
+            assert!(chmod(&path, Mode::from_bits_truncate(0o111)).is_err());
+        });
 
-        let ctime_after = stat(&path)?.st_ctime;
-        test_assert_eq!(ctime_after, ctime_before);
+        let ctime_after = stat(&path).unwrap().st_ctime;
+        assert_eq!(ctime_after, ctime_before);
     }
-
-    Ok(())
 }
 
-fn test_clear_isgid_bit(ctx: &mut TestContext) -> TestResult {
-    let path = ctx.create(FileType::Regular)?;
-    chmod(&path, Mode::from_bits_truncate(0o0755))?;
+fn test_clear_isgid_bit(ctx: &mut TestContext) {
+    let path = ctx.create(FileType::Regular).unwrap();
+    chmod(&path, Mode::from_bits_truncate(0o0755)).unwrap();
 
     let user = Uid::from_raw(65535);
     let group = Gid::from_raw(65535);
 
-    chown(&path, Some(user), Some(group))?;
+    chown(&path, Some(user), Some(group)).unwrap();
 
     let expected_mode = Mode::from_bits_truncate(0o2755);
     ctx.as_user(Some(user), Some(group), || {
-        chmod(&path, expected_mode)?;
-        Ok(())
-    })?;
+        chmod(&path, expected_mode).unwrap();
+    });
 
-    let actual_mode = stat(&path)?.st_mode;
-    test_assert_eq!(actual_mode & 0o7777, expected_mode.bits());
+    let actual_mode = stat(&path).unwrap().st_mode;
+    assert_eq!(actual_mode & 0o7777, expected_mode.bits());
 
     let expected_mode = Mode::from_bits_truncate(0o0755);
     ctx.as_user(Some(user), Some(group), || {
-        chmod(&path, expected_mode)?;
-        Ok(())
-    })?;
+        chmod(&path, expected_mode).unwrap();
+    });
 
-    let actual_mode = stat(&path)?.st_mode;
-    test_assert_eq!(actual_mode & 0o7777, expected_mode.bits());
+    let actual_mode = stat(&path).unwrap().st_mode;
+    assert_eq!(actual_mode & 0o7777, expected_mode.bits());
     //TODO: FreeBSD "S_ISGID should be removed and chmod(2) should success and FreeBSD returns EPERM."
-
-    Ok(())
 }


### PR DESCRIPTION
This replaces the result handling code with a panic handling one.
It uses `catch_unwind` to "capture" panics and a dummy panic hook (for now) to remove panic message.
However, the use of `AssertUnwindSafe` for the `TestContext` in the runner and the panic resuming in [`TestContext::as_user`](https://github.com/musikid/pjdfstest/commit/740dab897fbb90ad3f42a9e3bdd9249e49df80a4#diff-0820635a4c58dd02c508edb9e4bdeda7ef7e97c20f2efe416944b582792a8ce3R84-R86) needs to be reviewed.

Closes #5 
