### PR TITLE
Automate test collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,36 +21,36 @@ The package is made of the tests, and a test runner to launch them.
 
 To present how tests are organized, we take the `chmod` syscall as example.
 
-For each syscall being tested, 
-a test group which contains all the test cases 
-related to this syscall should be created.
+There is a separate module for each syscall being tested.  Within each of those
+modules, there may be either a single file, or a separate file for each aspect
+of the syscall.
 
 The hierarchy is like this:
 
 ```mermaid
 graph TD
-TG[Test group<br /><i>chmod</i>] --> TC1[Test case<br /><i>errno</i>]
+TG[Syscall module<br /><i>chmod</i>] --> TC1[Aspect<br /><i>errno</i>]
 
-TC1 --> TC1F1[Test function]
-TC1 --> TC1F2[Test function]
-TC1 --> TC1F3[Test function]
-TC1 --> TC1F4[Test function]
+TC1 --> TC1F1[Test case]
+TC1 --> TC1F2[Test case]
+TC1 --> TC1F3[Test case]
+TC1 --> TC1F4[Test case]
 
-TG --> TC2[Test case<br /><i>permission</i>]
+TG --> TC2[Aspect<br /><i>permission</i>]
 
-TC2 --> TC2F1[Test function]
-TC2 --> TC2F2[Test function]
+TC2 --> TC2F1[Test case]
+TC2 --> TC2F2[Test case]
 ```
 
 ### Layout
 
 ```tree
 src/tests
-├── chmod (syscall/test group)
-│   ├── errno.rs (test case)
-│   ├── mod.rs (test group declaration)
-│   └── permission.rs (test case)
-└── mod.rs (test groups modules declarations)
+├── chmod (syscall)
+│   ├── errno.rs (aspect)
+│   ├── mod.rs (syscall declaration)
+│   └── permission.rs (aspect)
+└── mod.rs (glues syscalls together)
 ```
 
 #### tests/mod.rs
@@ -61,42 +61,36 @@ All the modules for the test groups should be declared in this file.
 pub mod chmod;
 ```
 
-#### Test group
+#### Syscall module
 
-A test group contains test cases related to a specific syscall.
+A syscall module contains test cases related to a specific syscall.
 Its declaration should be in the `mod.rs` file 
 of the relevant folder (`chmod/` in our case).
+Common syscall-specific helpers can go here.
 
-```rust
-crate::pjdfs_group!(chmod; permission::test_case, errno::test_case);
-```
+### Aspect
 
-#### Test case
-
-A test case is made of test functions
-related to a specific functionality.
-All the test functions and the test case declaration 
-should be grouped in a single module.
-It means, either:
+An optional aspect module contains test cases that all relate to a common
+aspect of the syscall.
+Here "aspect" is a subjective area of related functionality.
+The aspect module may be either:
 
 - in a single file, which contains all the test functions and the case declaration,
 - in a folder, which contains multiple modules for the test functions and a `mod.rs` file, in which the case is declared.
 
 Though, except in the case of a very large set of test functions, it is better to write all in a single file.
 
-For example, in `chmod/permission.rs`, the test case declaration would be:
+#### Test case
 
-```rust
-pjdfs_test_case!(permission, { test: test_ctime });
-```
+Each test case exercises a minimal piece of the syscall's functionality.
+Each must be registered with the `test_case!` macro.
 
-#### Test function
-
-For now, a test function take a `&mut TestContext` parameter.
+For now, a test function takes a `&mut TestContext` parameter.
 
 ```rust,ignore
 // chmod/00.t:L58
-fn test_ctime(ctx: &mut TestContext) {
+crate::test_case!{ctime, Syscall::Chmod}
+fn ctime(ctx: &mut TestContext) {
     for f_type in FileType::iter().filter(|ft| *ft != FileType::Symlink(None)) {
         let path = ctx.create(f_type).unwrap();
         let ctime_before = stat(&path).unwrap().st_ctime;

--- a/book/src/test-declaration.md
+++ b/book/src/test-declaration.md
@@ -6,7 +6,8 @@ For example:
 
 ```rust,ignore
 // chmod/00.t:L58
-fn test_ctime(ctx: &mut TestContext) {
+crate::test_case!{Syscall::Chmod, ctime}
+fn ctime(ctx: &mut TestContext) {
     for f_type in FileType::iter().filter(|ft| *ft != FileType::Symlink(None)) {
         let path = ctx.create(f_type).unwrap();
         let ctime_before = stat(&path).unwrap().st_ctime;
@@ -52,7 +53,7 @@ To declare that a test function require root privileges,
 For example:
 
 ```rust
-pjdfs_test_case!(permission, { test: test_ctime, require_root: true });
+test_case!{change_perm, root, Syscall::Chmod}
 ```
 
 ## TODO: Platform-specific functions 

--- a/book/src/tests-structure.md
+++ b/book/src/tests-structure.md
@@ -3,7 +3,7 @@
 The tests should be grouped by syscalls, in the `tests/` folder.
 Each folder then have a `mod.rs` file, 
 which contains declarations of the modules inside this folder,
-and a `pjdfs_group!` statement to export the test cases from these modules.
+and a `group!` statement to export the test cases from these modules.
 For example:
 
 ### Layout
@@ -20,22 +20,20 @@ chmod (syscall/test group)
 ```rust,ignore
 mod permission;
 mod lchmod;
-
-crate::pjdfs_group!(chmod; permission::test_case, errno::test_case);
 ```
 
-Each module inside a group should export a test case (with `pjdfs_test_case`),
-which contains a list of test functions.
+Each module inside a group should register its test cases with `test_case!`.
 In our example, `chmod/permission.rs` would be:
 
 ```rust,ignore
+test_case!{ctime, root, Syscall::Chmod}
 use crate::{
-    pjdfs_test_case,
+    test_case,
     test::{TestContext, TestResult},
 };
 
 // chmod/00.t:L58
-fn test_ctime(ctx: &mut TestContext) -> TestResult {
+fn ctime(ctx: &mut TestContext) -> TestResult {
   for f_type in FileType::iter().filter(|&ft| ft == FileType::Symlink) {
       let path = ctx.create(f_type).map_err(TestError::CreateFile)?;
       let ctime_before = stat(&path)?.st_ctime;
@@ -50,6 +48,4 @@ fn test_ctime(ctx: &mut TestContext) -> TestResult {
 
   Ok(())
 }
-
-pjdfs_test_case!(permission, { test: test_ctime });
 ```

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -27,6 +27,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "ctor"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,6 +57,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghost"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93490550b1782c589a350f2211fff2e34682e25fed17ef53fc4fa8fe184975e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +80,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0257e268c91daba296499206db5dd5a058875936bec3d8429b5f3e20ec9dc9a"
+dependencies = [
+ "ctor",
+ "ghost",
 ]
 
 [[package]]
@@ -99,6 +130,7 @@ name = "pjdfs_tests"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "inventory",
  "nix",
  "once_cell",
  "rand",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+inventory = "0.3.0"
 tempfile = "3.3.0"
 rand = "0.8.5"
 thiserror = "1.0.31"

--- a/rust/src/macros.rs
+++ b/rust/src/macros.rs
@@ -1,93 +1,22 @@
-/// Create a group of tests, by creating/exporting a `tests` variable,
-/// which can then be used with the test runner.
 #[macro_export]
-macro_rules! pjdfs_group {
-    ($name:ident; $syscall:path; $( $group:path ),* $(,)*) => {
-       #[allow(non_snake_case, non_upper_case_globals)]
-       pub const tests: $crate::test::TestGroup = $crate::test::TestGroup {
-            name: stringify!($name),
-            syscall: $syscall,
-            test_cases: &[
-                $( $group ),*
-            ]
-        };
+macro_rules! test_case {
+    ( $f:path, root, $syscall:path ) => {
+        $crate::test_case!{$f, Some($syscall), true}
     };
-
-    ($name:ident; $( $group:path ),* $(,)*) => {
-       #[allow(non_snake_case, non_upper_case_globals)]
-       pub const tests: $crate::test::TestGroup = $crate::test::TestGroup {
-            name: stringify!($name),
-            syscall: None,
-            test_cases: &[
-                $( $group ),*
-            ]
-        };
+    ( $f:path, $syscall:path ) => {
+        $crate::test_case!{$f, Some($syscall), false}
     };
-}
-
-/// Create a test case, which is made of multiple test functions.
-/// An optional argument for executing exclusively on a particular file system can be provided.
-#[macro_export]
-macro_rules! pjdfs_test_case {
-    ($name:path $(,)? $(
-                    { test: $test:path
-                    $(, file_system: $fs:path)?
-                    $(, require_root: $require_root:expr)?
-                    }
-                ),* $(,)*) => {
-       #[allow(non_snake_case, non_upper_case_globals)]
-        pub const test_case: $crate::test::TestCase = $crate::test::TestCase {
-            name: stringify!($name),
-            tests: &[
-                $(
-                    $crate::pjdfs_test!({
-                        test: $test
-                        $(, file_system: $fs )?
-                        $(, require_root: $require_root)?
-                    })
-                ),*
-            ]
-        };
+    ( $f:path ) => {
+        $crate::test_case!{$f, None, false}
     };
-}
-
-/// Create a test function.
-/// An optional argument for executing exclusively on a particular file system can be provided.
-#[macro_export]
-macro_rules! pjdfs_test {
-    ({ test: $test: path }) => {
-        $crate::test::Test {
-            name: stringify!($test),
-            fun: $test,
-            file_system: None,
-            require_root: false,
-        }
-    };
-
-    ({ test: $test: path, file_system: $file_system: path }) => {
-        $crate::test::Test {
-            name: stringify!($test),
-            fun: $test,
-            file_system: Some($file_system),
-            require_root: false,
-        }
-    };
-
-    ({ test: $test: path, require_root: $require_root: expr }) => {
-        $crate::test::Test {
-            name: stringify!($test),
-            fun: $test,
-            file_system: None,
-            require_root: $require_root,
-        }
-    };
-
-    ({ test: $test: path, file_system: $file_system: path, require_root: $require_root: expr }) => {
-        $crate::test::Test {
-            name: stringify!($test),
-            fun: $test,
-            file_system: Some($file_system),
-            require_root: $require_root,
+    ( $f:path, $syscall:expr, $require_root:expr ) => {
+        ::inventory::submit! {
+            crate::test::TestCase {
+                name: concat!(module_path!(), "::", stringify!($f)),
+                syscall: $syscall,
+                require_root: $require_root,
+                fun: $f
+            }
         }
     };
 }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use once_cell::sync::OnceCell;
-use pjdfs_tests::{pjdfs_main, test::TestContext, tests::chmod};
+use pjdfs_tests::{pjdfs_main, test::{TestCase, TestContext}};
 
 struct PanicLocation(u32, u32, String);
 
@@ -23,37 +23,30 @@ fn main() -> anyhow::Result<()> {
         }
     }));
 
-    for group in [chmod::tests] {
-        for test_case in group.test_cases.iter() {
-            for test in test_case.tests {
-                print!(
-                    "{}\t",
-                    format!("{}::{}::{}", group.name, test_case.name, test.name)
-                );
-                stdout().lock().flush()?;
-                let mut context = TestContext::new();
-                //TODO: AssertUnwindSafe should be used with caution
-                let mut ctx_wrapper = AssertUnwindSafe(&mut context);
-                match catch_unwind(move || {
-                    (test.fun)(&mut ctx_wrapper);
-                }) {
-                    Ok(_) => println!("success"),
-                    Err(e) => {
-                        let location = PANIC_LOCATION.get().unwrap();
-                        anyhow::bail!(
-                            "{}
-                            Located in file {} at {}:{}
-                            ",
-                            e.downcast_ref::<String>()
-                                .cloned()
-                                .or_else(|| e.downcast_ref::<&str>().map(|&s| s.to_string()))
-                                .unwrap_or_default(),
-                            location.2,
-                            location.0,
-                            location.1
-                        )
-                    }
-                }
+    for tc2 in inventory::iter::<TestCase> {
+        print!("{}\t", tc2.name);
+        stdout().lock().flush()?;
+        let mut context = TestContext::new();
+        //TODO: AssertUnwindSafe should be used with caution
+        let mut ctx_wrapper = AssertUnwindSafe(&mut context);
+        match catch_unwind(move || {
+            (tc2.fun)(&mut ctx_wrapper);
+        }) {
+            Ok(_) => println!("success"),
+            Err(e) => {
+                let location = PANIC_LOCATION.get().unwrap();
+                anyhow::bail!(
+                    "{}
+                    Located in file {} at {}:{}
+                    ",
+                    e.downcast_ref::<String>()
+                        .cloned()
+                        .or_else(|| e.downcast_ref::<&str>().map(|&s| s.to_string()))
+                        .unwrap_or_default(),
+                    location.2,
+                    location.0,
+                    location.1
+                )
             }
         }
     }

--- a/rust/src/test.rs
+++ b/rust/src/test.rs
@@ -25,20 +25,17 @@ pub enum TestError {
     Nix(#[from] nix::Error),
 }
 
-/// A group of test cases.
-pub struct TestGroup {
-    pub name: &'static str,
-    pub test_cases: &'static [TestCase],
-    pub syscall: Option<Syscall>,
-}
-
-/// A test case, which is made of multiple test functions.
+/// A single minimal test case
 pub struct TestCase {
     pub name: &'static str,
-    pub tests: &'static [Test],
+    pub require_root: bool,
+    pub fun: fn(&mut TestContext),
+    pub syscall: Option<Syscall>
 }
 
 #[derive(Debug)]
 pub enum Syscall {
     Chmod,
 }
+
+inventory::collect!{TestCase}

--- a/rust/src/tests/chmod/errno.rs
+++ b/rust/src/tests/chmod/errno.rs
@@ -3,14 +3,13 @@ use nix::{
     sys::stat::{stat, Mode},
 };
 
-use crate::{pjdfs_test_case, runner::context::FileType, test::TestContext};
+use crate::{runner::context::FileType, test::{Syscall, TestContext}};
 
 use super::chmod;
 
-pjdfs_test_case!(errno, { test: test_enotdir, require_root: true }, { test: test_enametoolong });
-
+crate::test_case!{enotdir, root, Syscall::Chmod}
 /// Returns ENOTDIR if a component of the path prefix is not a directory
-fn test_enotdir(ctx: &mut TestContext) {
+fn enotdir(ctx: &mut TestContext) {
     for f_type in [
         FileType::Regular,
         FileType::Fifo,
@@ -26,8 +25,9 @@ fn test_enotdir(ctx: &mut TestContext) {
     }
 }
 
+crate::test_case!{enametoolong, Syscall::Chmod}
 /// chmod returns ENAMETOOLONG if a component of a pathname exceeded {NAME_MAX} characters
-fn test_enametoolong(ctx: &mut TestContext) {
+fn enametoolong(ctx: &mut TestContext) {
     let path = ctx.create_max(FileType::Regular).unwrap();
     let expected_mode = 0o620;
     chmod(&path, Mode::from_bits_truncate(expected_mode)).unwrap();

--- a/rust/src/tests/chmod/mod.rs
+++ b/rust/src/tests/chmod/mod.rs
@@ -11,5 +11,3 @@ fn chmod<P: ?Sized + nix::NixPath>(path: &P, mode: nix::sys::stat::Mode) -> nix:
         nix::sys::stat::FchmodatFlags::FollowSymlink,
     )
 }
-
-crate::pjdfs_group!(chmod; permission::test_case, errno::test_case);


### PR DESCRIPTION
Use the inventory crate to automatically produce the list of test
functions to run.  Under the hood, it makes use of linker sections to
build the list of test cases.

With automatic test collection, there is no longer any need for multiple
tiers of test organization, apart from what the Rust module system
provides.  So remove the group! and test_case! macros (the new
test_case! macro corresponds to the old "test function").

Finally, rename some functions to remove the redundant "test_" prefix.

Fixes #30
Fixes #28