### PR TITLE
Add configuration

### DIFF
--- a/book/src/configuration-file.md
+++ b/book/src/configuration-file.md
@@ -1,6 +1,7 @@
-# TODO: Configuration file
+# Configuration file
 
-The test runner can read a configuration file.
+The test runner can read a configuration file. For now, only the TOML format is supported.
+Its path can be specified by using the `-c PATH` flag.
 
 ## Sections
 
@@ -14,5 +15,12 @@ when executing the runner with `-l` argument.
 
 ```toml
 [features]
-posix_fallocate = true
+posix_fallocate = {}
+
+# Can also be specified by using key notation
+[features.posix_fallocate]
 ```
+
+#### Feature configuration
+
+TODO

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4,9 +4,18 @@ version = 3
 
 [[package]]
 name = "anyhow"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
+checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
+
+[[package]]
+name = "atomic"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b88d82667eca772c4aa12f0f1348b3ae643424c8876448f3f7bd5787032e234c"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "autocfg"
@@ -36,14 +45,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.2.6"
+name = "figment"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "790b4292c72618abbab50f787a477014fe15634f96291de45672ce46afe122df"
+dependencies = [
+ "atomic",
+ "serde",
+ "toml",
+ "uncased",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "gumdrop"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bc700f989d2f6f0248546222d9b4258f5b02a171a431f8285a81c08142629e3"
+dependencies = [
+ "gumdrop_derive",
+]
+
+[[package]]
+name = "gumdrop_derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "729f9bd3449d77e7831a18abfb7ba2f99ee813dfd15b8c2167c9a54ba20aa99d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -110,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "paste"
@@ -125,11 +167,14 @@ name = "pjdfs_tests"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "figment",
+ "gumdrop",
  "linkme",
  "nix",
  "once_cell",
  "paste",
  "rand",
+ "serde",
  "strum",
  "strum_macros",
  "tempfile",
@@ -144,18 +189,18 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
 ]
@@ -210,24 +255,44 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+checksum = "a0a5f7c728f5d284929a1cccb5bc19884422bfe6ef4d6c409da2c41838983fcf"
+
+[[package]]
+name = "serde"
+version = "1.0.138"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1578c6245786b9d168c5447eeacfb96856573ca56c9d68fdcf394be134882a47"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.138"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "023e9b1467aef8a10fb88f25611870ada9800ef7e22afce356bb0d2387b6f27c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "strum"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96acfc1b70604b8b2f1ffa4c57e59176c7dbb05d556c71ecd2f5498a1dee7f8"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.24.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
+checksum = "4faebde00e8ff94316c01800f9054fd2ba77d30d9e922541913051d1d978918b"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -238,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.96"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -282,16 +347,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.0"
+name = "toml"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "uncased"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b01702b0fd0b3fadcf98e098780badda8742d4f4a7676615cad90e8ac73622"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,6 +13,9 @@ anyhow = "1.0.57"
 once_cell = "1.12.0"
 linkme = "0.3.0"
 paste = "1.0.7"
+gumdrop = "0.8.1"
+figment = { version = "0.10.6", features = ["toml"] }
+serde = { version = "1.0.138", features = ["derive"] }
 
 [dependencies.nix]
 version = "0.24.1"

--- a/rust/pjdfstest.toml
+++ b/rust/pjdfstest.toml
@@ -1,0 +1,8 @@
+# Configuration for the test runner
+
+# This section allows enabling opt-in syscalls.
+# A list of these syscalls is provided when executing the runner with `-l`.
+[features]
+
+# Here is an example with the `posix_fallocate` syscall.
+[features.posix_fallocate]

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -1,0 +1,12 @@
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct FeatureConfig {}
+
+#[derive(Debug, Deserialize)]
+pub struct Config {
+    /// Opt-in syscalls.
+    pub features: HashMap<String, FeatureConfig>,
+}

--- a/rust/src/config.toml
+++ b/rust/src/config.toml
@@ -1,5 +1,0 @@
-# Configuration for pjdfs_runner
-
-# This section allows to enable opt-in test groups.
-# A list of these groups should be provided when executing the runner with `-l`.
-[features]

--- a/rust/src/macros.rs
+++ b/rust/src/macros.rs
@@ -3,6 +3,9 @@ macro_rules! test_case {
     ( $f:ident, root, $syscall:path ) => {
         $crate::test_case! {$f, Some($syscall), true}
     };
+    ( $f:ident, root ) => {
+        $crate::test_case! {$f, None, true}
+    };
     ( $f:ident, $syscall:path ) => {
         $crate::test_case! {$f, Some($syscall), false}
     };

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,19 +1,66 @@
 use std::{
+    collections::HashSet,
     io::{stdout, Write},
     panic::{catch_unwind, set_hook, AssertUnwindSafe, Location, PanicInfo},
+    path::{Path, PathBuf},
 };
 
+use config::Config;
+use figment::{
+    providers::{Format, Toml},
+    Figment,
+};
+use gumdrop::Options;
 use once_cell::sync::OnceCell;
+use strum::IntoEnumIterator;
+
 use pjdfs_tests::{
     pjdfs_main,
-    test::{TestCase, TestContext, TEST_CASES},
+    test::{ExclFeature, TestCase, TestContext, TEST_CASES},
 };
+
+mod config;
 
 struct PanicLocation(u32, u32, String);
 
 static PANIC_LOCATION: OnceCell<PanicLocation> = OnceCell::new();
 
+#[derive(Debug, Options)]
+struct ArgOptions {
+    #[options(help = "print help message")]
+    help: bool,
+
+    #[options(help = "Path of the configuration file")]
+    configuration_file: Option<PathBuf>,
+
+    #[options(help = "List opt-in syscalls")]
+    list_syscalls: bool,
+}
+
 fn main() -> anyhow::Result<()> {
+    let args = ArgOptions::parse_args_default_or_exit();
+
+    if args.list_syscalls {
+        for feature in ExclFeature::iter() {
+            println!("{}", feature);
+        }
+        return Ok(());
+    }
+
+    let config: Config = Figment::new()
+        .merge(Toml::file(
+            args.configuration_file
+                .as_deref()
+                .unwrap_or(Path::new("pjdfstest.toml")),
+        ))
+        .extract()?;
+
+    let enabled_features: HashSet<ExclFeature> = config
+        .features
+        .keys()
+        .filter_map(|k| k.as_str().try_into().ok())
+        .collect();
+
     set_hook(Box::new(|ctx| {
         if let Some(location) = ctx.location() {
             let _ = PANIC_LOCATION.set(PanicLocation(
@@ -27,6 +74,16 @@ fn main() -> anyhow::Result<()> {
     }));
 
     for test_case in TEST_CASES {
+        if let Some(sc) = &test_case.syscall {
+            if !enabled_features.contains(sc) {
+                println!(
+                    "skipped {}: please add it to the configuration file if you want to run it",
+                    sc
+                );
+                continue;
+            }
+        }
+
         print!("{}\t", test_case.name);
         stdout().lock().flush()?;
         let mut context = TestContext::new();

--- a/rust/src/test.rs
+++ b/rust/src/test.rs
@@ -8,15 +8,6 @@ pub use crate::runner::context::TestContext;
 
 pub type TestResult = std::result::Result<(), TestError>;
 
-/// A single test function.
-/// Can also be run exclusively on a particular file system.
-pub struct Test {
-    pub name: &'static str,
-    pub fun: fn(&mut TestContext),
-    pub file_system: Option<String>,
-    pub require_root: bool,
-}
-
 /// Error returned by a test function.
 #[derive(Error, Debug)]
 pub enum TestError {

--- a/rust/src/test.rs
+++ b/rust/src/test.rs
@@ -31,13 +31,14 @@ pub struct TestCase {
     pub name: &'static str,
     pub require_root: bool,
     pub fun: fn(&mut TestContext),
-    pub syscall: Option<Syscall>,
+    pub syscall: Option<ExclSyscall>,
 }
 
 #[distributed_slice]
 pub static TEST_CASES: [TestCase] = [..];
 
-#[derive(Debug)]
-pub enum Syscall {
-    Chmod,
+/// Syscalls which are not available on every OS/file system combination.
+#[derive(Debug, strum::IntoStaticStr)]
+pub enum ExclSyscall {
+    PosixFallocate,
 }

--- a/rust/src/test.rs
+++ b/rust/src/test.rs
@@ -22,14 +22,15 @@ pub struct TestCase {
     pub name: &'static str,
     pub require_root: bool,
     pub fun: fn(&mut TestContext),
-    pub syscall: Option<ExclSyscall>,
+    pub syscall: Option<ExclFeature>,
 }
 
 #[distributed_slice]
 pub static TEST_CASES: [TestCase] = [..];
 
 /// Syscalls which are not available on every OS/file system combination.
-#[derive(Debug, strum::IntoStaticStr)]
-pub enum ExclSyscall {
+#[derive(Debug, PartialEq, Eq, Hash, strum::EnumString, strum::Display, strum::EnumIter)]
+#[strum(serialize_all = "snake_case")]
+pub enum ExclFeature {
     PosixFallocate,
 }

--- a/rust/src/tests/chmod/errno.rs
+++ b/rust/src/tests/chmod/errno.rs
@@ -3,11 +3,11 @@ use nix::{
     sys::stat::{stat, Mode},
 };
 
-use crate::{runner::context::FileType, test::{Syscall, TestContext}};
+use crate::{runner::context::FileType, test::TestContext};
 
 use super::chmod;
 
-crate::test_case!{enotdir, root, Syscall::Chmod}
+crate::test_case! {enotdir, root}
 /// Returns ENOTDIR if a component of the path prefix is not a directory
 fn enotdir(ctx: &mut TestContext) {
     for f_type in [
@@ -25,7 +25,7 @@ fn enotdir(ctx: &mut TestContext) {
     }
 }
 
-crate::test_case!{enametoolong, Syscall::Chmod}
+crate::test_case! {enametoolong}
 /// chmod returns ENAMETOOLONG if a component of a pathname exceeded {NAME_MAX} characters
 fn enametoolong(ctx: &mut TestContext) {
     let path = ctx.create_max(FileType::Regular).unwrap();

--- a/rust/src/tests/chmod/permission.rs
+++ b/rust/src/tests/chmod/permission.rs
@@ -1,6 +1,6 @@
 use std::{thread::sleep, time::Duration};
 
-use crate::{runner::context::FileType, test::{Syscall, TestContext}, tests::chmod::chmod};
+use crate::{runner::context::FileType, test::TestContext, tests::chmod::chmod};
 use nix::{
     sys::stat::{lstat, mode_t, stat, Mode},
     unistd::{chown, Gid, Uid},
@@ -10,7 +10,7 @@ use strum::IntoEnumIterator;
 const FILE_PERMS: mode_t = 0o777;
 
 // chmod/00.t:L24
-crate::test_case!{change_perm, root, Syscall::Chmod}
+crate::test_case! {change_perm, root}
 fn change_perm(ctx: &mut TestContext) {
     for f_type in FileType::iter().filter(|ft| *ft != FileType::Symlink(None)) {
         let path = ctx.create(f_type).unwrap();
@@ -40,7 +40,7 @@ fn change_perm(ctx: &mut TestContext) {
 }
 
 // chmod/00.t:L58
-crate::test_case!{ctime, root, Syscall::Chmod}
+crate::test_case! {ctime, root}
 fn ctime(ctx: &mut TestContext) {
     for f_type in FileType::iter().filter(|ft| *ft != FileType::Symlink(None)) {
         let path = ctx.create(f_type).unwrap();
@@ -56,7 +56,7 @@ fn ctime(ctx: &mut TestContext) {
 }
 
 // chmod/00.t:L89
-crate::test_case!{failed_chmod_unchanged_ctime, root, Syscall::Chmod}
+crate::test_case! {failed_chmod_unchanged_ctime, root}
 fn failed_chmod_unchanged_ctime(ctx: &mut TestContext) {
     for f_type in FileType::iter().filter(|ft| *ft != FileType::Symlink(None)) {
         let path = ctx.create(f_type).unwrap();
@@ -73,7 +73,7 @@ fn failed_chmod_unchanged_ctime(ctx: &mut TestContext) {
     }
 }
 
-crate::test_case!{clear_isgid_bit, Syscall::Chmod}
+crate::test_case! {clear_isgid_bit}
 fn clear_isgid_bit(ctx: &mut TestContext) {
     let path = ctx.create(FileType::Regular).unwrap();
     chmod(&path, Mode::from_bits_truncate(0o0755)).unwrap();


### PR DESCRIPTION
This adds a configuration file for the test runner, which allows enabling "opt-in" syscalls.
These syscalls are available on all platforms, but aren't supported by all file systems.
It also adds basic argument parsing, for specifying configuration path and listing opt-in syscalls.

Closes #9