### PR TITLE
Add file types parameterization

### DIFF
--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -9,14 +9,14 @@ This is a complete rewrite of the original test suite in Rust.
 
 ## Build
 
-```sh
+```bash
 cd rust
 cargo run
 ```
 
 ### Run as root
 
-```
+```bash
 cd rust
 cargo build && sudo ./target/debug/pjdfs_runner
 ```

--- a/rust/src/macros.rs
+++ b/rust/src/macros.rs
@@ -1,16 +1,16 @@
 #[macro_export]
 macro_rules! test_case {
-    ( $f:ident, root, $syscall:path ) => {
-        $crate::test_case! {$f, Some($syscall), true}
+    ( $f:ident, root, $syscall:path $(=> $ftypes: tt )?) => {
+        $crate::test_case! {$f, Some($syscall), true $(=> $ftypes)?}
     };
-    ( $f:ident, root ) => {
-        $crate::test_case! {$f, None, true}
+    ( $f:ident, root $(=> $ftypes: tt )?) => {
+        $crate::test_case! {$f, None, true $(=> $ftypes)?}
     };
-    ( $f:ident, $syscall:path ) => {
-        $crate::test_case! {$f, Some($syscall), false}
+    ( $f:ident, $syscall:path $(=> $ftypes: tt )?) => {
+        $crate::test_case! {$f, Some($syscall), false $(=> $ftypes)?}
     };
-    ( $f:ident ) => {
-        $crate::test_case! {$f, None, false}
+    ( $f:ident $(=> $ftypes: tt )?) => {
+        $crate::test_case! {$f, None, false $(=> $ftypes)?}
     };
     ( $f:ident, $syscall:expr, $require_root:expr ) => {
         paste::paste! {
@@ -22,5 +22,18 @@ macro_rules! test_case {
                 fun: $f,
             };
         }
+    };
+    ( $f:ident, $syscall:expr, $require_root:expr => [$(FileType::$file_type: tt $(($ft_args: tt))?),+ $(,)*]) => {
+        $(
+            paste::paste! {
+                #[linkme::distributed_slice($crate::test::TEST_CASES)]
+                static [<CASE_$f:upper$file_type:upper>]: $crate::test::TestCase = crate::test::TestCase {
+                    name: concat!(module_path!(), "::", stringify!($f), "::", stringify!([<$file_type:lower>]), "_type"),
+                    syscall: $syscall,
+                    require_root: $require_root || FileType::$file_type $( ($ft_args ) )?.privileged(),
+                    fun: |ctx| $f(ctx, FileType::$file_type $( ($ft_args ) )?),
+                };
+            }
+        )+
     };
 }

--- a/rust/src/macros.rs
+++ b/rust/src/macros.rs
@@ -23,15 +23,15 @@ macro_rules! test_case {
             };
         }
     };
-    ( $f:ident, $syscall:expr, $require_root:expr => [$(FileType::$file_type: tt $(($ft_args: tt))?),+ $(,)*]) => {
+    ( $f:ident, $syscall:expr, $require_root:expr => [$( FileType:: $file_type:tt $( ($ft_args: tt) )? ),+ $(,)*]) => {
         $(
             paste::paste! {
                 #[linkme::distributed_slice($crate::test::TEST_CASES)]
                 static [<CASE_$f:upper$file_type:upper>]: $crate::test::TestCase = crate::test::TestCase {
                     name: concat!(module_path!(), "::", stringify!($f), "::", stringify!([<$file_type:lower>]), "_type"),
                     syscall: $syscall,
-                    require_root: $require_root || FileType::$file_type $( ($ft_args ) )?.privileged(),
-                    fun: |ctx| $f(ctx, FileType::$file_type $( ($ft_args ) )?),
+                    require_root: $require_root || FileType::$file_type $( ($ft_args) )?.privileged(),
+                    fun: |ctx| $f(ctx, FileType::$file_type $( ($ft_args) )?),
                 };
             }
         )+

--- a/rust/src/runner/context.rs
+++ b/rust/src/runner/context.rs
@@ -30,6 +30,21 @@ pub enum FileType {
     Symlink(Option<PathBuf>),
 }
 
+impl FileType {
+    pub const fn privileged(&self) -> bool {
+        match self {
+            FileType::Regular => false,
+            FileType::Dir => false,
+            //TODO: Not sure for FIFO
+            FileType::Fifo => false,
+            FileType::Block => true,
+            FileType::Char => true,
+            FileType::Socket => false,
+            FileType::Symlink(..) => false,
+        }
+    }
+}
+
 const NUM_RAND_CHARS: usize = 32;
 
 #[derive(Error, Debug)]

--- a/rust/src/tests/chmod/errno.rs
+++ b/rust/src/tests/chmod/errno.rs
@@ -7,22 +7,14 @@ use crate::{runner::context::FileType, test::TestContext};
 
 use super::chmod;
 
-crate::test_case! {enotdir, root}
+crate::test_case! {enotdir => [FileType::Regular, FileType::Fifo, FileType::Block, FileType::Char, FileType::Socket]}
 /// Returns ENOTDIR if a component of the path prefix is not a directory
-fn enotdir(ctx: &mut TestContext) {
-    for f_type in [
-        FileType::Regular,
-        FileType::Fifo,
-        FileType::Block,
-        FileType::Char,
-        FileType::Socket,
-    ] {
-        let not_dir = ctx.create(f_type).unwrap();
-        let fake_path = not_dir.join("test");
-        let res = chmod(&fake_path, Mode::from_bits_truncate(0o0644));
-        assert!(res.is_err());
-        assert_eq!(res.unwrap_err(), Errno::ENOTDIR);
-    }
+fn enotdir(ctx: &mut TestContext, f_type: FileType) {
+    let not_dir = ctx.create(f_type).unwrap();
+    let fake_path = not_dir.join("test");
+    let res = chmod(&fake_path, Mode::from_bits_truncate(0o0644));
+    assert!(res.is_err());
+    assert_eq!(res.unwrap_err(), Errno::ENOTDIR);
 }
 
 crate::test_case! {enametoolong}

--- a/rust/src/tests/chmod/permission.rs
+++ b/rust/src/tests/chmod/permission.rs
@@ -10,7 +10,7 @@ use strum::IntoEnumIterator;
 const FILE_PERMS: mode_t = 0o777;
 
 // chmod/00.t:L24
-crate::test_case! {change_perm => [FileType::Regular, FileType::Fifo, FileType::Block, FileType::Char, FileType::Socket]}
+crate::test_case! {change_perm => [FileType::Regular, FileType::Dir, FileType::Fifo, FileType::Block, FileType::Char, FileType::Socket]}
 fn change_perm(ctx: &mut TestContext, f_type: FileType) {
     let path = ctx.create(f_type).unwrap();
     let expected_mode = Mode::from_bits_truncate(0o111);
@@ -38,7 +38,7 @@ fn change_perm(ctx: &mut TestContext, f_type: FileType) {
 }
 
 // chmod/00.t:L58
-crate::test_case! {ctime => [FileType::Regular, FileType::Fifo, FileType::Block, FileType::Char, FileType::Socket]}
+crate::test_case! {ctime => [FileType::Regular, FileType::Dir, FileType::Fifo, FileType::Block, FileType::Char, FileType::Socket]}
 fn ctime(ctx: &mut TestContext, f_type: FileType) {
     let path = ctx.create(f_type).unwrap();
     let ctime_before = stat(&path).unwrap().st_ctime;
@@ -52,7 +52,7 @@ fn ctime(ctx: &mut TestContext, f_type: FileType) {
 }
 
 // chmod/00.t:L89
-crate::test_case! {failed_chmod_unchanged_ctime => [FileType::Regular, FileType::Fifo, FileType::Block, FileType::Char, FileType::Socket]}
+crate::test_case! {failed_chmod_unchanged_ctime => [FileType::Regular, FileType::Dir, FileType::Fifo, FileType::Block, FileType::Char, FileType::Socket]}
 fn failed_chmod_unchanged_ctime(ctx: &mut TestContext, f_type: FileType) {
     let path = ctx.create(f_type).unwrap();
     let ctime_before = stat(&path).unwrap().st_ctime;


### PR DESCRIPTION
Improves the case declaration by adding support for file types. For each specified file type, a new test case structure is created. It also automatically declare root requirement for privileged file types.
This will allow future parallelization for these tests, and seems to already improve actual runtimes.

Closes #1 