### PR TITLE
Add file system exclusive feature

### DIFF
--- a/book/src/configuration-file.md
+++ b/book/src/configuration-file.md
@@ -31,10 +31,7 @@ TODO
 
 #### file_flags
 
-Several UNIX operating systems have a concept of "file flags",
-which adds an additional level of security and control.
-Some tests are related to this feature and therefore
-need it to be supported. 
+Some tests are related to file flags. 
 However, not all file systems and operating systems support all flags.
 To give a sufficient level of granularity, each supported flag can be
 specified in the configuration with the `file_flags` array.

--- a/book/src/configuration-file.md
+++ b/book/src/configuration-file.md
@@ -25,6 +25,10 @@ posix_fallocate = {}
 [features.posix_fallocate]
 ```
 
+#### Feature configuration
+
+TODO
+
 #### file_flags
 
 Several UNIX operating systems have a concept of "file flags",
@@ -41,7 +45,3 @@ specified in the configuration with the `file_flags` array.
 posix_fallocate = {}
 file_flags = ["UF_IMMUTABLE"]
 ```
-
-#### Feature configuration
-
-TODO

--- a/book/src/configuration-file.md
+++ b/book/src/configuration-file.md
@@ -35,8 +35,7 @@ Several UNIX operating systems have a concept of "file flags",
 which adds an additional level of security and control.
 Some tests are related to this feature and therefore
 need it to be supported. 
-However, the support of these flags is depedent of the file system,
-and some file systems don't support at all any flag.
+However, not all file systems and operating systems support all flags.
 To give a sufficient level of granularity, each supported flag can be
 specified in the configuration with the `file_flags` array.
 

--- a/book/src/configuration-file.md
+++ b/book/src/configuration-file.md
@@ -11,7 +11,7 @@ Some features are not available for every file system.
 For tests requiring such features,
 the execution becomes opt-in.
 The user can enable their execution,
- by adding the corresponding feature as a key in this section.
+by adding the corresponding feature as a key in this section.
 A list of these opt-in features is provided
 when executing the runner with `-l` argument.
 

--- a/book/src/configuration-file.md
+++ b/book/src/configuration-file.md
@@ -7,18 +7,39 @@ Its path can be specified by using the `-c PATH` flag.
 
 ### [features]
 
-Some syscalls cannot be run on all combinations of file systems/platforms.
-Their execution is opt-in,
-as in the user should enable them by adding the key in this section.
-A list of these opt-in groups should be provided 
+Some features are not available for every file system.
+For tests requiring such features,
+the execution becomes opt-in.
+The user can enable their execution,
+ by adding the corresponding feature as a key in this section.
+A list of these opt-in features is provided
 when executing the runner with `-l` argument.
 
-```toml
+For example, with `posix_fallocate`:
+
+ ```toml
 [features]
 posix_fallocate = {}
 
 # Can also be specified by using key notation
 [features.posix_fallocate]
+```
+
+#### file_flags
+
+Several UNIX operating systems have a concept of "file flags",
+which adds an additional level of security and control.
+Some tests are related to this feature and therefore
+need it to be supported. 
+However, the support of these flags is depedent of the file system,
+and some file systems don't support at all any flag.
+To give a sufficient level of granularity, each supported flag can be
+specified in the configuration with the `file_flags` array.
+
+```toml
+[features]
+posix_fallocate = {}
+file_flags = ["UF_IMMUTABLE"]
 ```
 
 #### Feature configuration

--- a/book/src/test-declaration.md
+++ b/book/src/test-declaration.md
@@ -34,49 +34,47 @@ to modify the execution of the tests or add requirements.
 
 Some features are not available for every file system.
 For tests requiring such features, the execution becomes opt-in.
-They can be declared by adding them after eventual `root` requirement
-and before the file types.
-Every variant of `FileSystemFeature` can be specified.
+When a test need such feature, a variant of `FileSystemFeature` corresponding to this feature should be specified,
+by adding it after eventual `root` requirement and before the file types.
+Multiple features can be specified, with a comma `,` separator.
+
+For example:
 
 ```rust,ignore
 #[cfg(target_os = "freebsd")]
-crate::test_case! {eperm_immutable_flag, FileSystemFeature::Chflags, FileSystemFeature::FileFlags(&[FileFlags::SF_IMMUTABLE])}
-#[cfg(target_os = "freebsd")]
-fn eperm_immutable_flag(ctx: &mut TestContext) {
-    let path = ctx.create(FileType::Regular).unwrap();
-    //TODO: Complete
-}
+crate::test_case! {eperm_immutable_flag, FileSystemFeature::Chflags, FileSystemFeature::PosixFallocate ...}
 ```
 
-#### File flags (MIGHT CHANGE)
+#### File flags
+
+**NOTE: This feature is not supported by all POSIX systems, 
+therefore its use needs a `#[cfg(target_os = ...)]` attribute, specifying supported system(s).
+Please see [Rust reference](https://doc.rust-lang.org/reference/conditional-compilation.html#target_os) for more information.**
 
 It is possible to specify individual file flags for the tests which
-requires it. `FileSystemFeature::FileFlags` takes a slice parameter,
-which is made of the used file flags.
-
-##### Warning: There is also a `FileFlags` defined for `nix`.
+require it. They can be specified by appending `FileFlags` variants after a `;` separator,
+after (eventual) `root` and features.
 
 ```rust,ignore
-test_case! { ..., FileSystemFeature::FileFlags(&[FileFlags::UF_IMMUTABLE, FileFlags::SF_IMMUTABLE])} }
+crate::test_case! {eperm_immutable_flag, root, FileSystemFeature::Chflags; FileFlags::SF_IMMUTABLE, FileFlags::UF_IMMUTABLE}
 ```
-
-##### NOTE: The file flags feature is the only one to have a parameter, and probably should stay that way.
 
 #### Adding features
 
-
+New features can be added to the `FileSystemFeature` enum.
 
 ### File types
 
 Some test cases need to test over different file types.
 The file types should be added at the end of the test case declaration,
-within brackets, with a fat arrow before (`=> [FileType::Regular]`).
+within brackets and with a fat arrow before (`=> [FileType::Regular]`).
 The test function should also accept a `FileType` parameter to operate on.
 
 For example:
 
 ```rust,ignore
-crate::test_case! {change_perm => [FileType::Regular, FileType::Fifo, FileType::Block, FileType::Char, FileType::Socket]}
+crate::test_case! {change_perm, root, FileSystemFeature::Chflags; FileFlags::SF_IMMUTABLE, FileFlags::UF_IMMUTABLE 
+=> [FileType::Regular, FileType::Fifo, FileType::Block, FileType::Char, FileType::Socket]}
 fn change_perm(ctx: &mut TestContext, f_type: FileType) {
 ```
 

--- a/book/src/test-declaration.md
+++ b/book/src/test-declaration.md
@@ -48,7 +48,7 @@ crate::test_case! {eperm_immutable_flag, FileSystemFeature::Chflags, FileSystemF
 #### File flags
 
 **NOTE: This feature is not supported by all POSIX systems, 
-therefore its use needs a `#[cfg(target_os = ...)]` attribute, specifying supported system(s).
+therefore its use needs a `#[cfg(target_os = ...)]` attribute specifying supported system(s).
 Please see [Rust reference](https://doc.rust-lang.org/reference/conditional-compilation.html#target_os) for more information.**
 
 It is possible to specify individual file flags for the tests which
@@ -56,12 +56,33 @@ require it. They can be specified by appending `FileFlags` variants after a `;` 
 after (eventual) `root` and features.
 
 ```rust,ignore
+#[cfg(target_os = "freebsd")]
 crate::test_case! {eperm_immutable_flag, root, FileSystemFeature::Chflags; FileFlags::SF_IMMUTABLE, FileFlags::UF_IMMUTABLE}
+```
+
+Here is a list of the OS which support file flags:
+
+```rust,ignore
+{{#include ../../rust/src/test.rs:file_flags_os}}
 ```
 
 #### Adding features
 
 New features can be added to the `FileSystemFeature` enum.
+
+### Root privileges
+
+Some tests may need root privileges to run.
+To declare that a test function require root privileges, 
+`root` should be added to its declaration.
+For example:
+
+```rust,ignore
+crate::test_case!{change_perm, root}
+```
+
+The root requirement is automatically added for privileged file types,
+namely block and char.
 
 ### File types
 
@@ -77,20 +98,6 @@ crate::test_case! {change_perm, root, FileSystemFeature::Chflags; FileFlags::SF_
 => [FileType::Regular, FileType::Fifo, FileType::Block, FileType::Char, FileType::Socket]}
 fn change_perm(ctx: &mut TestContext, f_type: FileType) {
 ```
-
-### Root privileges
-
-Some tests may need root privileges to run.
-To declare that a test function require root privileges, 
-`root` should be added to its declaration.
-For example:
-
-```rust,ignore
-crate::test_case!{change_perm, root}
-```
-
-The root requirement is automatically added for privileged file types,
-namely block and char.
 
 ## TODO: Platform-specific functions 
 

--- a/book/src/test-declaration.md
+++ b/book/src/test-declaration.md
@@ -49,7 +49,6 @@ crate::test_case! {eperm_immutable_flag, FileSystemFeature::Chflags, FileSystemF
 
 **NOTE: This feature is not supported by all POSIX systems, 
 therefore its use needs a `#[cfg(target_os = ...)]` attribute specifying supported system(s).
-Please see [Rust reference](https://doc.rust-lang.org/reference/conditional-compilation.html#target_os) for more information.**
 
 It is possible to specify individual file flags for the tests which
 require it. They can be specified by appending `FileFlags` variants after a `;` separator,

--- a/book/src/test-declaration.md
+++ b/book/src/test-declaration.md
@@ -27,16 +27,55 @@ fn ctime(ctx: &mut TestContext, f_type: FileType) {
 
 ## Parameterization
 
+It is possible to give additional parameters to the test case macro,
+to modify the execution of the tests or add requirements.
+
+### File-system exclusive features
+
+Some features are not available for every file system.
+For tests requiring such features, the execution becomes opt-in.
+They can be declared by adding them after eventual `root` requirement
+and before the file types.
+Every variant of `FileSystemFeature` can be specified.
+
+```rust,ignore
+#[cfg(target_os = "freebsd")]
+crate::test_case! {eperm_immutable_flag, FileSystemFeature::Chflags, FileSystemFeature::FileFlags(&[FileFlags::SF_IMMUTABLE])}
+#[cfg(target_os = "freebsd")]
+fn eperm_immutable_flag(ctx: &mut TestContext) {
+    let path = ctx.create(FileType::Regular).unwrap();
+    //TODO: Complete
+}
+```
+
+#### File flags (MIGHT CHANGE)
+
+It is possible to specify individual file flags for the tests which
+requires it. `FileSystemFeature::FileFlags` takes a slice parameter,
+which is made of the used file flags.
+
+##### Warning: There is also a `FileFlags` defined for `nix`.
+
+```rust,ignore
+test_case! { ..., FileSystemFeature::FileFlags(&[FileFlags::UF_IMMUTABLE, FileFlags::SF_IMMUTABLE])} }
+```
+
+##### NOTE: The file flags feature is the only one to have a parameter, and probably should stay that way.
+
+#### Adding features
+
+
+
 ### File types
 
 Some test cases need to test over different file types.
 The file types should be added at the end of the test case declaration,
-with brackets and an fat arrow before (`=> [FileType::Regular]`).
+within brackets, with a fat arrow before (`=> [FileType::Regular]`).
 The test function should also accept a `FileType` parameter to operate on.
 
 For example:
 
-```rust
+```rust,ignore
 crate::test_case! {change_perm => [FileType::Regular, FileType::Fifo, FileType::Block, FileType::Char, FileType::Socket]}
 fn change_perm(ctx: &mut TestContext, f_type: FileType) {
 ```
@@ -48,7 +87,7 @@ To declare that a test function require root privileges,
 `root` should be added to its declaration.
 For example:
 
-```rust
+```rust,ignore
 crate::test_case!{change_perm, root}
 ```
 

--- a/rust/pjdfstest.toml
+++ b/rust/pjdfstest.toml
@@ -1,8 +1,14 @@
-# Configuration for the test runner
+# Configuration for the pjdfstest runner
 
-# This section allows enabling opt-in syscalls.
-# A list of these syscalls is provided when executing the runner with `-l`.
+# This section allows enabling file system specific features.
+# Please see the book for more details.
+# A list of these features is provided when executing the runner with `-l`.
 [features]
+# File flags can be specified for OS which supports them.
+# file_flags = ["UF_IMMUTABLE"]
 
 # Here is an example with the `posix_fallocate` syscall.
+posix_fallocate = {}
+
+# Might use the key notation as well.
 [features.posix_fallocate]

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -1,14 +1,5 @@
 use std::collections::HashMap;
 
-#[cfg(any(
-    target_os = "openbsd",
-    target_os = "netbsd",
-    target_os = "freebsd",
-    target_os = "dragonfly",
-    target_os = "macos",
-    target_os = "ios",
-    target_os = "watchos",
-))]
 use pjdfs_tests::test::FileFlags;
 use pjdfs_tests::test::FileSystemFeature;
 use serde::Deserialize;
@@ -20,16 +11,8 @@ pub struct CommonFeatureConfig {}
 /// Please see the book for more details.
 #[derive(Debug, Deserialize)]
 pub struct FeaturesConfig {
-    #[cfg(any(
-        target_os = "openbsd",
-        target_os = "netbsd",
-        target_os = "freebsd",
-        target_os = "dragonfly",
-        target_os = "macos",
-        target_os = "ios",
-        target_os = "watchos",
-    ))]
-    pub file_flags: Option<Vec<FileFlags>>,
+    #[serde(default)]
+    pub file_flags: Vec<FileFlags>,
     #[serde(flatten)]
     pub fs_features: HashMap<FileSystemFeature, CommonFeatureConfig>,
 }

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -1,12 +1,39 @@
 use std::collections::HashMap;
 
+#[cfg(any(
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "freebsd",
+    target_os = "dragonfly",
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "watchos",
+))]
+use pjdfs_tests::test::FileFlags;
+use pjdfs_tests::test::FileSystemFeature;
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
-pub struct FeatureConfig {}
+pub struct CommonFeatureConfig {}
+
+#[derive(Debug, Deserialize)]
+pub struct FeaturesConfig {
+    #[cfg(any(
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "watchos",
+    ))]
+    pub file_flags: Option<Vec<FileFlags>>,
+    #[serde(flatten)]
+    pub fs_features: HashMap<FileSystemFeature, CommonFeatureConfig>,
+}
 
 #[derive(Debug, Deserialize)]
 pub struct Config {
-    /// Opt-in syscalls.
-    pub features: HashMap<String, FeatureConfig>,
+    /// File-system features.
+    pub features: FeaturesConfig,
 }

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -16,6 +16,8 @@ use serde::Deserialize;
 #[derive(Debug, Deserialize)]
 pub struct CommonFeatureConfig {}
 
+/// Configuration for file-system specific features.
+/// Please see the book for more details.
 #[derive(Debug, Deserialize)]
 pub struct FeaturesConfig {
     #[cfg(any(

--- a/rust/src/feature.rs
+++ b/rust/src/feature.rs
@@ -1,4 +1,0 @@
-pub struct Feature {
-    name: String,
-    variant: ExclFeature,
-}

--- a/rust/src/feature.rs
+++ b/rust/src/feature.rs
@@ -1,0 +1,4 @@
+pub struct Feature {
+    name: String,
+    variant: ExclFeature,
+}

--- a/rust/src/macros.rs
+++ b/rust/src/macros.rs
@@ -1,35 +1,35 @@
 #[macro_export]
 macro_rules! test_case {
-    ( $f:ident, root, $syscall:path $(=> $ftypes: tt )?) => {
-        $crate::test_case! {$f, Some($syscall), true $(=> $ftypes)?}
+    ($f:ident, root, $( $features:expr ),+ $(,)* $(=> $ftypes: tt )?) => {
+        $crate::test_case! {@ $f, Some(&[$( $features ),+]), true $(=> $ftypes)?}
     };
-    ( $f:ident, root $(=> $ftypes: tt )?) => {
-        $crate::test_case! {$f, None, true $(=> $ftypes)?}
+    ($f:ident, root $(=> $ftypes: tt )?) => {
+        $crate::test_case! {@ $f, None, true $(=> $ftypes)?}
     };
-    ( $f:ident, $syscall:path $(=> $ftypes: tt )?) => {
-        $crate::test_case! {$f, Some($syscall), false $(=> $ftypes)?}
+    ($f:ident, $( $features:expr ),+ $(,)* $(=> $ftypes: tt )?) => {
+        $crate::test_case! {@ $f, Some(&[$( $features ),+]), false $(=> $ftypes)?}
     };
-    ( $f:ident $(=> $ftypes: tt )?) => {
-        $crate::test_case! {$f, None, false $(=> $ftypes)?}
+    ($f:ident $(=> $ftypes: tt )?) => {
+        $crate::test_case! {@ $f, None, false $(=> $ftypes)?}
     };
-    ( $f:ident, $syscall:expr, $require_root:expr ) => {
+    (@ $f:ident, $features:expr, $require_root:expr) => {
         paste::paste! {
             #[linkme::distributed_slice($crate::test::TEST_CASES)]
-            static [<CASE_$f:upper>]: $crate::test::TestCase = crate::test::TestCase {
+            static [<CASE_$f:upper>]: $crate::test::TestCase = $crate::test::TestCase {
                 name: concat!(module_path!(), "::", stringify!($f)),
-                syscall: $syscall,
+                required_features: $features,
                 require_root: $require_root,
                 fun: $f,
             };
         }
     };
-    ( $f:ident, $syscall:expr, $require_root:expr => [$( FileType:: $file_type:tt $( ($ft_args: tt) )? ),+ $(,)*]) => {
+    (@ $f:ident, $features:expr, $require_root:expr => [$( FileType:: $file_type:tt $( ($ft_args: tt) )? ),+ $(,)*]) => {
         $(
             paste::paste! {
                 #[linkme::distributed_slice($crate::test::TEST_CASES)]
-                static [<CASE_$f:upper$file_type:upper>]: $crate::test::TestCase = crate::test::TestCase {
+                static [<CASE_$f:upper$file_type:upper>]: $crate::test::TestCase = $crate::test::TestCase {
                     name: concat!(module_path!(), "::", stringify!($f), "::", stringify!([<$file_type:lower>]), "_type"),
-                    syscall: $syscall,
+                    required_features: $features,
                     require_root: $require_root || FileType::$file_type $( ($ft_args) )?.privileged(),
                     fun: |ctx| $f(ctx, FileType::$file_type $( ($ft_args) )?),
                 };

--- a/rust/src/macros.rs
+++ b/rust/src/macros.rs
@@ -1,35 +1,54 @@
 #[macro_export]
 macro_rules! test_case {
     ($f:ident, root, $( $features:expr ),+ $(,)* $(=> $ftypes: tt )?) => {
-        $crate::test_case! {@ $f, Some(&[$( $features ),+]), true $(=> $ftypes)?}
+        $crate::test_case! {@ $f, &[$( $features ),+], &[], true $(=> $ftypes)?}
     };
-    ($f:ident, root $(=> $ftypes: tt )?) => {
-        $crate::test_case! {@ $f, None, true $(=> $ftypes)?}
+    ($f:ident $(,)* $( $features:expr ),* $(,)* ; $( $flags:expr ),+ $(=> $ftypes: tt )?) => {
+        $crate::test_case! {@ $f, &[$( $features ),*], &[$( $flags ),+], false $(=> $ftypes)?}
     };
-    ($f:ident, $( $features:expr ),+ $(,)* $(=> $ftypes: tt )?) => {
-        $crate::test_case! {@ $f, Some(&[$( $features ),+]), false $(=> $ftypes)?}
+    ($f:ident $(,)* $( $features:expr ),* $(,)* $(=> $ftypes: tt )?) => {
+        $crate::test_case! {@ $f, &[$( $features ),*], &[], false $(=> $ftypes)?}
     };
-    ($f:ident $(=> $ftypes: tt )?) => {
-        $crate::test_case! {@ $f, None, false $(=> $ftypes)?}
-    };
-    (@ $f:ident, $features:expr, $require_root:expr) => {
+
+
+    (@ $f:ident, $features:expr, $flags:expr, $require_root:expr) => {
         paste::paste! {
             #[linkme::distributed_slice($crate::test::TEST_CASES)]
             static [<CASE_$f:upper>]: $crate::test::TestCase = $crate::test::TestCase {
                 name: concat!(module_path!(), "::", stringify!($f)),
                 required_features: $features,
+                #[cfg(any(
+                    target_os = "openbsd",
+                    target_os = "netbsd",
+                    target_os = "freebsd",
+                    target_os = "dragonfly",
+                    target_os = "macos",
+                    target_os = "ios",
+                    target_os = "watchos",
+                ))]
+                required_file_flags: $flags,
                 require_root: $require_root,
                 fun: $f,
             };
         }
     };
-    (@ $f:ident, $features:expr, $require_root:expr => [$( FileType:: $file_type:tt $( ($ft_args: tt) )? ),+ $(,)*]) => {
+    (@ $f:ident, $features:expr, $flags:expr, $require_root:expr => [$( FileType:: $file_type:tt $( ($ft_args: tt) )? ),+ $(,)*]) => {
         $(
             paste::paste! {
                 #[linkme::distributed_slice($crate::test::TEST_CASES)]
                 static [<CASE_$f:upper$file_type:upper>]: $crate::test::TestCase = $crate::test::TestCase {
                     name: concat!(module_path!(), "::", stringify!($f), "::", stringify!([<$file_type:lower>]), "_type"),
                     required_features: $features,
+                    #[cfg(any(
+                        target_os = "openbsd",
+                        target_os = "netbsd",
+                        target_os = "freebsd",
+                        target_os = "dragonfly",
+                        target_os = "macos",
+                        target_os = "ios",
+                        target_os = "watchos",
+                    ))]
+                    required_file_flags: $flags,
                     require_root: $require_root || FileType::$file_type $( ($ft_args) )?.privileged(),
                     fun: |ctx| $f(ctx, FileType::$file_type $( ($ft_args) )?),
                 };

--- a/rust/src/macros.rs
+++ b/rust/src/macros.rs
@@ -17,15 +17,6 @@ macro_rules! test_case {
             static [<CASE_$f:upper>]: $crate::test::TestCase = $crate::test::TestCase {
                 name: concat!(module_path!(), "::", stringify!($f)),
                 required_features: $features,
-                #[cfg(any(
-                    target_os = "openbsd",
-                    target_os = "netbsd",
-                    target_os = "freebsd",
-                    target_os = "dragonfly",
-                    target_os = "macos",
-                    target_os = "ios",
-                    target_os = "watchos",
-                ))]
                 required_file_flags: $flags,
                 require_root: $require_root,
                 fun: $f,
@@ -39,15 +30,6 @@ macro_rules! test_case {
                 static [<CASE_$f:upper$file_type:upper>]: $crate::test::TestCase = $crate::test::TestCase {
                     name: concat!(module_path!(), "::", stringify!($f), "::", stringify!([<$file_type:lower>]), "_type"),
                     required_features: $features,
-                    #[cfg(any(
-                        target_os = "openbsd",
-                        target_os = "netbsd",
-                        target_os = "freebsd",
-                        target_os = "dragonfly",
-                        target_os = "macos",
-                        target_os = "ios",
-                        target_os = "watchos",
-                    ))]
                     required_file_flags: $flags,
                     require_root: $require_root || FileType::$file_type $( ($ft_args) )?.privileged(),
                     fun: |ctx| $f(ctx, FileType::$file_type $( ($ft_args) )?),

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -101,7 +101,7 @@ fn main() -> anyhow::Result<()> {
         if let Some(features) = &test_case.required_features {
             let features = features.iter().cloned().collect::<HashSet<_>>();
             let missing_features = features.difference(&enabled_features);
-            if !missing_features.clone().count() > 0 {
+            if missing_features.clone().count() > 0 {
                 println!(
                     "skipped {}, please add the following features to your configuration:",
                     test_case.name
@@ -120,16 +120,12 @@ fn main() -> anyhow::Result<()> {
                                 target_os = "watchos",
                             ))]
                             FileSystemFeature::FileFlags(flags) => {
-                                let flags = flags.iter().map(|f| f.to_string()).fold(
-                                    String::new(),
-                                    |mut acc, s| {
-                                        acc.push_str("\t");
-                                        acc.extend(s.chars());
-                                        acc.push_str(" = true\n");
-                                        acc
-                                    },
-                                );
-                                format!("[features.file_flags]\n{}", flags)
+                                let flags = flags
+                                    .iter()
+                                    .map(|f| format(r#""{}""#, f))
+                                    .collect::<Vec<_>>()
+                                    .join(", ");
+                                format!("[features]\nfile_flags = [{}]", flags)
                             }
                             _ => format!("[features.{}]", feature.to_string()),
                         }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -52,13 +52,7 @@ fn main() -> anyhow::Result<()> {
         ))
         .extract()?;
 
-    let enabled_features: HashSet<_> = config
-        .features
-        .fs_features
-        .keys()
-        .into_iter()
-        .cloned()
-        .collect();
+    let enabled_features: HashSet<_> = config.features.fs_features.keys().into_iter().collect();
 
     set_hook(Box::new(|ctx| {
         if let Some(location) = ctx.location() {
@@ -72,7 +66,7 @@ fn main() -> anyhow::Result<()> {
         }
     }));
 
-    let enabled_flags: HashSet<_> = config.features.file_flags.iter().cloned().collect();
+    let enabled_flags: HashSet<_> = config.features.file_flags.iter().collect();
 
     for test_case in TEST_CASES {
         //TODO: There's probably a better way to do this...
@@ -80,11 +74,7 @@ fn main() -> anyhow::Result<()> {
 
         let mut message = None;
 
-        let features = test_case
-            .required_features
-            .iter()
-            .cloned()
-            .collect::<HashSet<_>>();
+        let features = test_case.required_features.iter().collect::<HashSet<_>>();
         let missing_features = features.difference(&enabled_features);
         if missing_features.clone().count() > 0 {
             should_skip = true;
@@ -100,7 +90,7 @@ fn main() -> anyhow::Result<()> {
             *message += "\n";
         }
 
-        let required_flags: HashSet<_> = test_case.required_file_flags.iter().cloned().collect();
+        let required_flags: HashSet<_> = test_case.required_file_flags.iter().collect();
         let missing_flags = required_flags.difference(&enabled_flags);
 
         if missing_flags.clone().count() > 0 {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -122,7 +122,7 @@ fn main() -> anyhow::Result<()> {
                             FileSystemFeature::FileFlags(flags) => {
                                 let flags = flags
                                     .iter()
-                                    .map(|f| format(r#""{}""#, f))
+                                    .map(|f| format!(r#""{}""#, f))
                                     .collect::<Vec<_>>()
                                     .join(", ");
                                 format!("[features]\nfile_flags = [{}]", flags)

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -72,22 +72,7 @@ fn main() -> anyhow::Result<()> {
         }
     }));
 
-    #[cfg(any(
-        target_os = "openbsd",
-        target_os = "netbsd",
-        target_os = "freebsd",
-        target_os = "dragonfly",
-        target_os = "macos",
-        target_os = "ios",
-        target_os = "watchos",
-    ))]
-    let enabled_flags: HashSet<_> = config
-        .features
-        .file_flags
-        .unwrap_or_default()
-        .iter()
-        .cloned()
-        .collect();
+    let enabled_flags: HashSet<_> = config.features.file_flags.iter().cloned().collect();
 
     for test_case in TEST_CASES {
         //TODO: There's probably a better way to do this...
@@ -111,36 +96,24 @@ fn main() -> anyhow::Result<()> {
                 .collect::<String>();
         }
 
-        #[cfg(any(
-            target_os = "openbsd",
-            target_os = "netbsd",
-            target_os = "freebsd",
-            target_os = "dragonfly",
-            target_os = "macos",
-            target_os = "ios",
-            target_os = "watchos",
-        ))]
-        {
-            let required_flags: HashSet<_> =
-                test_case.required_file_flags.iter().cloned().collect();
-            let missing_flags = required_flags.difference(&enabled_flags);
+        let required_flags: HashSet<_> = test_case.required_file_flags.iter().cloned().collect();
+        let missing_flags = required_flags.difference(&enabled_flags);
 
-            if missing_flags.clone().count() > 0 {
-                should_skip = true;
+        if missing_flags.clone().count() > 0 {
+            should_skip = true;
 
-                let flags: String = missing_flags
-                    .map(|f| {
-                        let f = f.to_string();
+            let flags: String = missing_flags
+                .map(|f| {
+                    let f = f.to_string();
 
-                        ["\"", f.as_str(), "\""].join("")
-                    })
-                    .collect::<Vec<_>>()
-                    .join(", ");
+                    ["\"", f.as_str(), "\""].join("")
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
 
-                let message = message.get_or_insert(String::new());
-                *message += "please add the following flags to your configuration:\n";
-                *message += &format!("\tfile_flags = [{}]\n", flags);
-            }
+            let message = message.get_or_insert(String::new());
+            *message += "please add the following flags to your configuration:\n";
+            *message += &format!("\tfile_flags = [{}]\n", flags);
         }
 
         if should_skip {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -74,12 +74,13 @@ fn main() -> anyhow::Result<()> {
 
         let mut message = None;
 
-        let features = test_case.required_features.iter().collect::<HashSet<_>>();
-        let missing_features = features.difference(&enabled_features);
-        if missing_features.clone().count() > 0 {
+        let features: HashSet<_> = test_case.required_features.iter().collect();
+        let missing_features: Vec<_> = features.difference(&enabled_features).collect();
+        if !missing_features.is_empty() {
             should_skip = true;
 
             let features = &missing_features
+                .iter()
                 .map(|feature| format!("{}", feature))
                 .collect::<Vec<_>>()
                 .join(", ");
@@ -91,12 +92,12 @@ fn main() -> anyhow::Result<()> {
         }
 
         let required_flags: HashSet<_> = test_case.required_file_flags.iter().collect();
-        let missing_flags = required_flags.difference(&enabled_flags);
-
-        if missing_flags.clone().count() > 0 {
+        let missing_flags: Vec<_> = required_flags.difference(&enabled_flags).collect();
+        if !missing_flags.is_empty() {
             should_skip = true;
 
             let flags: String = missing_flags
+                .iter()
                 .map(|f| {
                     let f = f.to_string();
 

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -89,11 +89,15 @@ fn main() -> anyhow::Result<()> {
         if missing_features.clone().count() > 0 {
             should_skip = true;
 
+            let features = &missing_features
+                .map(|feature| format!("{}", feature))
+                .collect::<Vec<_>>()
+                .join(", ");
+
             let message = message.get_or_insert(String::new());
-            *message += "please add the following features to your configuration:\n";
-            *message += &missing_features
-                .map(|feature| format!("\t[features.{}]\n", feature))
-                .collect::<String>();
+            *message += "requires features: ";
+            *message += &features;
+            *message += "\n";
         }
 
         let required_flags: HashSet<_> = test_case.required_file_flags.iter().cloned().collect();
@@ -106,14 +110,15 @@ fn main() -> anyhow::Result<()> {
                 .map(|f| {
                     let f = f.to_string();
 
-                    ["\"", f.as_str(), "\""].join("")
+                    ["\"", &f, "\""].join("")
                 })
                 .collect::<Vec<_>>()
                 .join(", ");
 
             let message = message.get_or_insert(String::new());
-            *message += "please add the following flags to your configuration:\n";
-            *message += &format!("\tfile_flags = [{}]\n", flags);
+            *message += "requires flags: ";
+            *message += &flags;
+            *message += "\n";
         }
 
         if should_skip {

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -72,7 +72,7 @@ fn main() -> anyhow::Result<()> {
         //TODO: There's probably a better way to do this...
         let mut should_skip = false;
 
-        let mut message = None;
+        let mut message = String::new();
 
         let features: HashSet<_> = test_case.required_features.iter().collect();
         let missing_features: Vec<_> = features.difference(&enabled_features).collect();
@@ -85,10 +85,9 @@ fn main() -> anyhow::Result<()> {
                 .collect::<Vec<_>>()
                 .join(", ");
 
-            let message = message.get_or_insert(String::new());
-            *message += "requires features: ";
-            *message += &features;
-            *message += "\n";
+            message += "requires features: ";
+            message += &features;
+            message += "\n";
         }
 
         let required_flags: HashSet<_> = test_case.required_file_flags.iter().collect();
@@ -106,18 +105,13 @@ fn main() -> anyhow::Result<()> {
                 .collect::<Vec<_>>()
                 .join(", ");
 
-            let message = message.get_or_insert(String::new());
-            *message += "requires flags: ";
-            *message += &flags;
-            *message += "\n";
+            message += "requires flags: ";
+            message += &flags;
+            message += "\n";
         }
 
         if should_skip {
-            println!(
-                "skipped '{}'\n{}",
-                test_case.name,
-                message.unwrap_or_default()
-            );
+            println!("skipped '{}'\n{}", test_case.name, message);
             continue;
         }
 

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -95,7 +95,7 @@ fn main() -> anyhow::Result<()> {
         if !missing_flags.is_empty() {
             should_skip = true;
 
-            let flags: String = missing_flags
+            let flags = missing_flags
                 .iter()
                 .map(|f| {
                     let f = f.to_string();

--- a/rust/src/test.rs
+++ b/rust/src/test.rs
@@ -23,7 +23,17 @@ pub struct TestCase {
     pub name: &'static str,
     pub require_root: bool,
     pub fun: fn(&mut TestContext),
-    pub required_features: Option<&'static [FileSystemFeature]>,
+    pub required_features: &'static [FileSystemFeature],
+    #[cfg(any(
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "watchos",
+    ))]
+    pub required_file_flags: &'static [FileFlags],
 }
 
 #[distributed_slice]
@@ -123,19 +133,6 @@ pub enum FileFlags {
 pub enum FileSystemFeature {
     Chflags,
     ChflagsSfSnapshot,
-    #[strum(disabled)]
-    #[serde(skip)]
-    #[cfg(any(
-        target_os = "openbsd",
-        target_os = "netbsd",
-        target_os = "freebsd",
-        target_os = "dragonfly",
-        target_os = "macos",
-        target_os = "ios",
-        target_os = "watchos",
-    ))]
-    //TODO: Create another structure for flags? or directly add them into this enum?
-    FileFlags(&'static [FileFlags]),
     PosixFallocate,
     RenameCtime,
     StatStBirthtime,

--- a/rust/src/test.rs
+++ b/rust/src/test.rs
@@ -39,6 +39,7 @@ pub struct TestCase {
 #[distributed_slice]
 pub static TEST_CASES: [TestCase] = [..];
 
+// ANCHOR: file_flags_os
 #[cfg(any(
     target_os = "openbsd",
     target_os = "netbsd",
@@ -48,6 +49,7 @@ pub static TEST_CASES: [TestCase] = [..];
     target_os = "ios",
     target_os = "watchos",
 ))]
+// ANCHOR_END: file_flags_os
 #[allow(non_camel_case_types)]
 #[derive(
     Debug,

--- a/rust/src/test.rs
+++ b/rust/src/test.rs
@@ -50,8 +50,6 @@ pub static TEST_CASES: [TestCase] = [..];
     strum::EnumIter,
     Deserialize,
 )]
-#[strum(serialize_all = "snake_case")]
-#[serde(rename_all = "snake_case")]
 pub enum FileFlags {
     UF_SETTABLE,
     UF_NODUMP,

--- a/rust/src/test.rs
+++ b/rust/src/test.rs
@@ -18,7 +18,7 @@ pub enum TestError {
     Nix(#[from] nix::Error),
 }
 
-/// A single minimal test case
+/// A single minimal test case.
 pub struct TestCase {
     pub name: &'static str,
     pub require_root: bool,
@@ -50,6 +50,7 @@ pub static TEST_CASES: [TestCase] = [..];
     strum::EnumIter,
     Deserialize,
 )]
+/// File flags (see https://docs.freebsd.org/en/books/handbook/basics/#permissions).
 pub enum FileFlags {
     UF_SETTABLE,
     UF_NODUMP,
@@ -133,6 +134,7 @@ pub enum FileSystemFeature {
         target_os = "ios",
         target_os = "watchos",
     ))]
+    //TODO: Create another structure for flags? or directly add them into this enum?
     FileFlags(&'static [FileFlags]),
     PosixFallocate,
     RenameCtime,

--- a/rust/src/test.rs
+++ b/rust/src/test.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 
 use linkme::distributed_slice;
+use serde::Deserialize;
 use thiserror::Error;
 
 use crate::runner::context::ContextError;
@@ -22,15 +23,121 @@ pub struct TestCase {
     pub name: &'static str,
     pub require_root: bool,
     pub fun: fn(&mut TestContext),
-    pub syscall: Option<ExclFeature>,
+    pub required_features: Option<&'static [FileSystemFeature]>,
 }
 
 #[distributed_slice]
 pub static TEST_CASES: [TestCase] = [..];
 
-/// Syscalls which are not available on every OS/file system combination.
-#[derive(Debug, PartialEq, Eq, Hash, strum::EnumString, strum::Display, strum::EnumIter)]
+#[cfg(any(
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "freebsd",
+    target_os = "dragonfly",
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "watchos",
+))]
+#[allow(non_camel_case_types)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    strum::EnumString,
+    strum::Display,
+    strum::EnumIter,
+    Deserialize,
+)]
 #[strum(serialize_all = "snake_case")]
-pub enum ExclFeature {
+#[serde(rename_all = "snake_case")]
+pub enum FileFlags {
+    UF_SETTABLE,
+    UF_NODUMP,
+    UF_IMMUTABLE,
+    UF_APPEND,
+    UF_OPAQUE,
+
+    SF_SETTABLE,
+    SF_ARCHIVED,
+    SF_IMMUTABLE,
+    SF_APPEND,
+
+    #[cfg(any(target_os = "dragonfly"))]
+    UF_NOHISTORY,
+    #[cfg(any(target_os = "dragonfly"))]
+    UF_CACHE,
+    #[cfg(any(target_os = "dragonfly"))]
+    UF_XLINK,
+    #[cfg(any(target_os = "dragonfly"))]
+    SF_NOHISTORY,
+    #[cfg(any(target_os = "dragonfly"))]
+    SF_CACHE,
+    #[cfg(any(target_os = "dragonfly"))]
+    SF_XLINK,
+
+    #[cfg(any(target_os = "freebsd"))]
+    UF_SYSTEM,
+    #[cfg(any(target_os = "freebsd"))]
+    UF_SPARSE,
+    #[cfg(any(target_os = "freebsd"))]
+    UF_OFFLINE,
+    #[cfg(any(target_os = "freebsd"))]
+    UF_REPARSE,
+    #[cfg(any(target_os = "freebsd"))]
+    UF_ARCHIVE,
+    #[cfg(any(target_os = "freebsd"))]
+    UF_READONLY,
+
+    #[cfg(any(target_os = "freebsd", target_os = "netbsd"))]
+    SF_SNAPSHOT,
+
+    #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+    UF_NOUNLINK,
+    #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+    SF_NOUNLINK,
+
+    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "watchos"))]
+    UF_COMPRESSED,
+    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "watchos"))]
+    UF_TRACKED,
+
+    #[cfg(any(
+        target_os = "freebsd",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "watchos"
+    ))]
+    UF_HIDDEN,
+
+    #[cfg(any(target_os = "netbsd"))]
+    SF_LOG,
+    #[cfg(any(target_os = "netbsd"))]
+    SF_SNAPINVAL,
+}
+
+/// Features which are not available for every file system.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, strum::Display, strum::EnumIter, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum FileSystemFeature {
+    Chflags,
+    ChflagsSfSnapshot,
+    #[strum(disabled)]
+    #[serde(skip)]
+    #[cfg(any(
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "watchos",
+    ))]
+    FileFlags(&'static [FileFlags]),
     PosixFallocate,
+    RenameCtime,
+    StatStBirthtime,
+    UtimeNow,
 }

--- a/rust/src/test.rs
+++ b/rust/src/test.rs
@@ -24,32 +24,12 @@ pub struct TestCase {
     pub require_root: bool,
     pub fun: fn(&mut TestContext),
     pub required_features: &'static [FileSystemFeature],
-    #[cfg(any(
-        target_os = "openbsd",
-        target_os = "netbsd",
-        target_os = "freebsd",
-        target_os = "dragonfly",
-        target_os = "macos",
-        target_os = "ios",
-        target_os = "watchos",
-    ))]
     pub required_file_flags: &'static [FileFlags],
 }
 
 #[distributed_slice]
 pub static TEST_CASES: [TestCase] = [..];
 
-// ANCHOR: file_flags_os
-#[cfg(any(
-    target_os = "openbsd",
-    target_os = "netbsd",
-    target_os = "freebsd",
-    target_os = "dragonfly",
-    target_os = "macos",
-    target_os = "ios",
-    target_os = "watchos",
-))]
-// ANCHOR_END: file_flags_os
 #[allow(non_camel_case_types)]
 #[derive(
     Debug,
@@ -64,15 +44,96 @@ pub static TEST_CASES: [TestCase] = [..];
 )]
 /// File flags (see https://docs.freebsd.org/en/books/handbook/basics/#permissions).
 pub enum FileFlags {
+    #[cfg(any(
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "watchos",
+    ))]
     UF_SETTABLE,
+    #[cfg(any(
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "watchos",
+    ))]
     UF_NODUMP,
+    #[cfg(any(
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "watchos",
+    ))]
     UF_IMMUTABLE,
+    #[cfg(any(
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "watchos",
+    ))]
     UF_APPEND,
+    #[cfg(any(
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "watchos",
+    ))]
     UF_OPAQUE,
 
+    #[cfg(any(
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "watchos",
+    ))]
     SF_SETTABLE,
+    #[cfg(any(
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "watchos",
+    ))]
     SF_ARCHIVED,
+    #[cfg(any(
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "watchos",
+    ))]
     SF_IMMUTABLE,
+    #[cfg(any(
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "watchos",
+    ))]
     SF_APPEND,
 
     #[cfg(any(target_os = "dragonfly"))]

--- a/rust/src/tests/chmod/errno.rs
+++ b/rust/src/tests/chmod/errno.rs
@@ -5,6 +5,9 @@ use nix::{
 
 use crate::{runner::context::FileType, test::TestContext};
 
+#[cfg(target_os = "freebsd")]
+use crate::test::{FileFlags, FileSystemFeature};
+
 use super::chmod;
 
 crate::test_case! {enotdir => [FileType::Regular, FileType::Fifo, FileType::Block, FileType::Char, FileType::Socket]}
@@ -31,4 +34,12 @@ fn enametoolong(ctx: &mut TestContext) {
     let res = chmod(&too_long_path, Mode::from_bits_truncate(0o0620));
     assert!(res.is_err());
     assert_eq!(res.unwrap_err(), Errno::ENAMETOOLONG);
+}
+
+#[cfg(target_os = "freebsd")]
+crate::test_case! {eperm_immutable_flag, FileSystemFeature::Chflags, FileSystemFeature::FileFlags(&[FileFlags::SF_IMMUTABLE])}
+#[cfg(target_os = "freebsd")]
+fn eperm_immutable_flag(ctx: &mut TestContext) {
+    let path = ctx.create(FileType::Regular).unwrap();
+    //TODO: Complete
 }

--- a/rust/src/tests/chmod/errno.rs
+++ b/rust/src/tests/chmod/errno.rs
@@ -37,7 +37,7 @@ fn enametoolong(ctx: &mut TestContext) {
 }
 
 #[cfg(target_os = "freebsd")]
-crate::test_case! {eperm_immutable_flag, FileSystemFeature::Chflags, FileSystemFeature::FileFlags(&[FileFlags::SF_IMMUTABLE])}
+crate::test_case! {eperm_immutable_flag, FileSystemFeature::Chflags; FileFlags::SF_IMMUTABLE}
 #[cfg(target_os = "freebsd")]
 fn eperm_immutable_flag(ctx: &mut TestContext) {
     let path = ctx.create(FileType::Regular).unwrap();

--- a/rust/src/tests/chmod/permission.rs
+++ b/rust/src/tests/chmod/permission.rs
@@ -5,7 +5,6 @@ use nix::{
     sys::stat::{lstat, mode_t, stat, Mode},
     unistd::{chown, Gid, Uid},
 };
-use strum::IntoEnumIterator;
 
 const FILE_PERMS: mode_t = 0o777;
 


### PR DESCRIPTION
Adds support for specifying file system exclusive features,
which mimics the `require` function from the original test suite.
Also adds file flags requirement for additional granularity.
The runner skips tests which don't satisfy requirements and print what should be added to the configuration file to launch the test.

An example:

```rust
crate::test_case! {eperm_immutable_flag, FileSystemFeature::Chflags; FileFlags::SF_IMMUTABLE}
```
Closes #8