### PR TITLE
shorten the sleep duration

### DIFF
--- a/book/src/configuration-file.md
+++ b/book/src/configuration-file.md
@@ -41,3 +41,14 @@ specified in the configuration with the `file_flags` array.
 posix_fallocate = {}
 file_flags = ["UF_IMMUTABLE"]
 ```
+
+### [settings]
+
+```toml
+[settings]
+naptime = 0.001
+```
+
+* `naptime` - The duration for a "short" sleep.  It should be greater than the
+  timestamp granularity of the file system under test.  The default value is 1
+  second.

--- a/rust/pjdfstest.toml
+++ b/rust/pjdfstest.toml
@@ -12,3 +12,8 @@ posix_fallocate = {}
 
 # Might use the key notation as well.
 [features.posix_fallocate]
+
+[settings]
+# naptime is the duration of various short sleeps.  It should be greater than
+# the timestamp granularity of the file system under test.
+naptime = 0.001

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -17,8 +17,21 @@ pub struct FeaturesConfig {
     pub fs_features: HashMap<FileSystemFeature, CommonFeatureConfig>,
 }
 
+/// Adjustable file-system specific settings.
+/// Please see the book for more details.
+#[derive(Debug, Deserialize)]
+pub struct SettingsConfig {
+    #[serde(default = "default_naptime")]
+    pub naptime: f64
+}
+
+fn default_naptime() -> f64 {
+    1.0
+}
+
 #[derive(Debug, Deserialize)]
 pub struct Config {
     /// File-system features.
     pub features: FeaturesConfig,
+    pub settings: SettingsConfig
 }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -117,7 +117,7 @@ fn main() -> anyhow::Result<()> {
 
         print!("{}\t", test_case.name);
         stdout().lock().flush()?;
-        let mut context = TestContext::new();
+        let mut context = TestContext::new(&config.settings.naptime);
         //TODO: AssertUnwindSafe should be used with caution
         let mut ctx_wrapper = AssertUnwindSafe(&mut context);
         match catch_unwind(move || {

--- a/rust/src/tests/mod.rs
+++ b/rust/src/tests/mod.rs
@@ -1,1 +1,56 @@
+use std::os::unix::fs::MetadataExt as StdMetadataExt;
+use std::{
+    fs::metadata,
+    path::Path,
+    time::{Duration, SystemTime}
+};
+
+use crate::test::TestContext;
+
 pub mod chmod;
+
+/// A handy extention to std::os::unix::fs::MetadataExt
+trait MetadataExt: StdMetadataExt {
+    /// Return the file's last changed time as a `SystemTime`, including
+    /// fractional component.
+    fn ctime_sys(&self) -> SystemTime {
+        let nsec = u32::try_from(self.ctime_nsec())
+            .expect("File has denormalized timestamp");
+        if self.ctime() >= 0 {
+            SystemTime::UNIX_EPOCH + Duration::new(self.ctime() as u64, nsec)
+        } else {
+            SystemTime::UNIX_EPOCH - Duration::from_secs(-self.ctime() as u64)
+                + Duration::new(0, nsec)
+        }
+    }
+}
+
+impl<T: StdMetadataExt> MetadataExt for T {}
+
+/// Assert that a certain operation changes the ctime of a file.
+fn assert_ctime_changed<F>(ctx: &mut TestContext, path: &Path, f: F)
+    where F: FnOnce()
+{
+    let ctime_before = metadata(&path).unwrap().ctime_sys();
+
+    ctx.nap();
+
+    f();
+
+    let ctime_after = metadata(&path).unwrap().ctime_sys();
+    assert!(ctime_after > ctime_before);
+}
+
+/// Assert that a certain operation does not change the ctime of a file.
+fn assert_ctime_unchanged<F>(ctx: &TestContext, path: &Path, f: F)
+    where F: FnOnce()
+{
+    let ctime_before = metadata(&path).unwrap().ctime_sys();
+
+    ctx.nap();
+
+    f();
+
+    let ctime_after = metadata(&path).unwrap().ctime_sys();
+    assert!(ctime_after == ctime_before);
+}


### PR DESCRIPTION
The original pjdfstest contained numerous 1-second sleeps whose purpose
was to ensure that a file's timestamp changed after some operation.  But
those sleeps add up quickly, and are longer than usually necessary.

Instead, create a config file option that specifies the length of sleep
required, which can vary across OS and file system.  Only sleep for that
amount of time.