### PR TITLE
Less typing in test case declarations

### DIFF
--- a/rust/src/macros.rs
+++ b/rust/src/macros.rs
@@ -24,7 +24,7 @@ macro_rules! test_case {
             }
         }
     };
-    (@ $f:ident, $features:expr, $flags:expr, $require_root:expr => [$( FileType:: $file_type:tt $( ($ft_args: tt) )? ),+ $(,)*]) => {
+    (@ $f:ident, $features:expr, $flags:expr, $require_root:expr => [$( $file_type:tt $( ($ft_args: tt) )? ),+ $(,)*]) => {
         $(
             paste::paste! {
                 ::inventory::submit! {
@@ -32,8 +32,8 @@ macro_rules! test_case {
                         name: concat!(module_path!(), "::", stringify!($f), "::", stringify!([<$file_type:lower>])),
                         required_features: $features,
                         required_file_flags: $flags,
-                        require_root: $require_root || FileType::$file_type $( ($ft_args) )?.privileged(),
-                        fun: |ctx| $f(ctx, FileType::$file_type $( ($ft_args) )?),
+                        require_root: $require_root || crate::runner::context::FileType::$file_type $( ($ft_args) )?.privileged(),
+                        fun: |ctx| $f(ctx, crate::runner::context::FileType::$file_type $( ($ft_args) )?),
                     }
                 }
             }

--- a/rust/src/tests/chmod/errno.rs
+++ b/rust/src/tests/chmod/errno.rs
@@ -10,7 +10,7 @@ use crate::test::{FileFlags, FileSystemFeature};
 
 use super::chmod;
 
-crate::test_case! {enotdir => [FileType::Regular, FileType::Fifo, FileType::Block, FileType::Char, FileType::Socket]}
+crate::test_case! {enotdir => [Regular, Fifo, Block, Char, Socket]}
 /// Returns ENOTDIR if a component of the path prefix is not a directory
 fn enotdir(ctx: &mut TestContext, f_type: FileType) {
     let not_dir = ctx.create(f_type).unwrap();

--- a/rust/src/tests/chmod/permission.rs
+++ b/rust/src/tests/chmod/permission.rs
@@ -9,7 +9,7 @@ use nix::{
 const FILE_PERMS: mode_t = 0o777;
 
 // chmod/00.t:L24
-crate::test_case! {change_perm => [FileType::Regular, FileType::Dir, FileType::Fifo, FileType::Block, FileType::Char, FileType::Socket]}
+crate::test_case! {change_perm => [Regular, Dir, Fifo, Block, Char, Socket]}
 fn change_perm(ctx: &mut TestContext, f_type: FileType) {
     let path = ctx.create(f_type).unwrap();
     let expected_mode = Mode::from_bits_truncate(0o111);
@@ -37,7 +37,7 @@ fn change_perm(ctx: &mut TestContext, f_type: FileType) {
 }
 
 // chmod/00.t:L58
-crate::test_case! {ctime => [FileType::Regular, FileType::Dir, FileType::Fifo, FileType::Block, FileType::Char, FileType::Socket]}
+crate::test_case! {ctime => [Regular, Dir, Fifo, Block, Char, Socket]}
 fn ctime(ctx: &mut TestContext, f_type: FileType) {
     let path = ctx.create(f_type).unwrap();
     let ctime_before = stat(&path).unwrap().st_ctime;
@@ -51,7 +51,7 @@ fn ctime(ctx: &mut TestContext, f_type: FileType) {
 }
 
 // chmod/00.t:L89
-crate::test_case! {failed_chmod_unchanged_ctime => [FileType::Regular, FileType::Dir, FileType::Fifo, FileType::Block, FileType::Char, FileType::Socket]}
+crate::test_case! {failed_chmod_unchanged_ctime => [Regular, Dir, Fifo, Block, Char, Socket]}
 fn failed_chmod_unchanged_ctime(ctx: &mut TestContext, f_type: FileType) {
     let path = ctx.create(f_type).unwrap();
     let ctime_before = stat(&path).unwrap().st_ctime;


### PR DESCRIPTION
by moving FileType:: into the macro