### PR TITLE
Filter test names

### DIFF
--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -75,20 +75,19 @@ fn main() -> anyhow::Result<()> {
     let enabled_flags: HashSet<_> = config.features.file_flags.iter().collect();
 
     let test_cases = inventory::iter::<TestCase>;
-    let test_cases: Vec<_> =
-        test_cases
-            .into_iter()
-            .filter(|case| {
-                args.test_patterns.is_empty() || args.test_patterns.iter().any(|pat| {
+    let test_cases: Vec<_> = test_cases
+        .into_iter()
+        .filter(|case| {
+            args.test_patterns.is_empty()
+                || args.test_patterns.iter().any(|pat| {
                     if args.exact {
                         case.name == pat
                     } else {
                         case.name.contains(pat)
                     }
                 })
-            })
-            .collect()
-    };
+        })
+        .collect();
 
     for test_case in test_cases {
         //TODO: There's probably a better way to do this...

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -75,13 +75,11 @@ fn main() -> anyhow::Result<()> {
     let enabled_flags: HashSet<_> = config.features.file_flags.iter().collect();
 
     let test_cases = inventory::iter::<TestCase>;
-    let test_cases: Vec<_> = if args.test_patterns.is_empty() {
-        test_cases.into_iter().collect()
-    } else {
+    let test_cases: Vec<_> =
         test_cases
             .into_iter()
             .filter(|case| {
-                args.test_patterns.iter().any(|pat| {
+                args.test_patterns.is_empty() || args.test_patterns.iter().any(|pat| {
                     if args.exact {
                         case.name == pat
                     } else {


### PR DESCRIPTION
Adds a free argument which takes test filter patterns, using `str::contains`, and an `--exact` flag to match exactly against test names.

Closes #49