### PR TITLE
Improve test running

### DIFF
--- a/rust/src/macros.rs
+++ b/rust/src/macros.rs
@@ -1,21 +1,21 @@
 #[macro_export]
 macro_rules! test_case {
-    ($f:ident, root, $( $features:expr ),+ $(,)* $(=> $ftypes: tt )?) => {
-        $crate::test_case! {@ $f, &[$( $features ),+], &[], true $(=> $ftypes)?}
+    ($(#[doc = $docs:literal])*
+        $f:ident, root $(,)* $( $features:expr ),* $(,)* $(; $( $flags:expr ),+)? $(=> $ftypes: tt )?) => {
+        $crate::test_case! {@ $f, &[$( $features ),*], &[$( $( $flags ),+ )?], true, concat!($($docs),*) $(=> $ftypes)?}
     };
-    ($f:ident $(,)* $( $features:expr ),* $(,)* ; $( $flags:expr ),+ $(=> $ftypes: tt )?) => {
-        $crate::test_case! {@ $f, &[$( $features ),*], &[$( $flags ),+], false $(=> $ftypes)?}
-    };
-    ($f:ident $(,)* $( $features:expr ),* $(,)* $(=> $ftypes: tt )?) => {
-        $crate::test_case! {@ $f, &[$( $features ),*], &[], false $(=> $ftypes)?}
+    ($(#[doc = $docs:literal])*
+        $f:ident $(,)* $( $features:expr ),* $(,)* $(; $( $flags:expr ),+)? $(=> $ftypes: tt )?) => {
+        $crate::test_case! {@ $f, &[$( $features ),*], &[$( $( $flags ),+ )?], false, concat!($($docs),*) $(=> $ftypes)?}
     };
 
 
-    (@ $f:ident, $features:expr, $flags:expr, $require_root:expr) => {
+    (@ $f:ident, $features:expr, $flags:expr, $require_root:expr, $desc:expr ) => {
         paste::paste! {
             ::inventory::submit! {
                 $crate::test::TestCase {
                     name: concat!(module_path!(), "::", stringify!($f)),
+                    description: $desc,
                     required_features: $features,
                     required_file_flags: $flags,
                     require_root: $require_root,
@@ -24,12 +24,13 @@ macro_rules! test_case {
             }
         }
     };
-    (@ $f:ident, $features:expr, $flags:expr, $require_root:expr => [$( $file_type:tt $( ($ft_args: tt) )? ),+ $(,)*]) => {
+    (@ $f:ident, $features:expr, $flags:expr, $require_root:expr, $desc:expr => [$( $file_type:tt $( ($ft_args: tt) )? ),+ $(,)*]) => {
         $(
             paste::paste! {
                 ::inventory::submit! {
                     $crate::test::TestCase {
                         name: concat!(module_path!(), "::", stringify!($f), "::", stringify!([<$file_type:lower>])),
+                        description: $desc,
                         required_features: $features,
                         required_file_flags: $flags,
                         require_root: $require_root || crate::runner::context::FileType::$file_type $( ($ft_args) )?.privileged(),

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -36,6 +36,9 @@ struct ArgOptions {
     #[options(help = "Match names exactly")]
     exact: bool,
 
+    #[options(help = "Verbose mode")]
+    verbose: bool,
+
     #[options(free, help = "Filter test names")]
     test_patterns: Vec<String>,
 }
@@ -89,9 +92,9 @@ fn main() -> anyhow::Result<()> {
         })
         .collect();
 
-    let mut failed_tests_count = 0;
-    let mut succeeded_tests_count = 0;
-    let mut skipped_tests_count = 0;
+    let mut failed_tests_count: usize = 0;
+    let mut succeeded_tests_count: usize = 0;
+    let mut skipped_tests_count: usize = 0;
 
     for test_case in test_cases {
         //TODO: There's probably a better way to do this...
@@ -136,6 +139,13 @@ fn main() -> anyhow::Result<()> {
         }
 
         print!("{}\t", test_case.name);
+
+        if args.verbose {
+            if !test_case.description.is_empty() {
+                print!("\n\t{}\t\t", test_case.description);
+            }
+        }
+
         stdout().lock().flush()?;
 
         if should_skip {
@@ -179,5 +189,10 @@ fn main() -> anyhow::Result<()> {
         succeeded_tests_count,
         failed_tests_count + skipped_tests_count + succeeded_tests_count,
     );
-    Ok(())
+
+    if failed_tests_count > 0 {
+        Err(anyhow::anyhow!("Some tests have failed"))
+    } else {
+        Ok(())
+    }
 }

--- a/rust/src/test.rs
+++ b/rust/src/test.rs
@@ -20,6 +20,7 @@ pub enum TestError {
 /// A single minimal test case.
 pub struct TestCase {
     pub name: &'static str,
+    pub description: &'static str,
     pub require_root: bool,
     pub fun: fn(&mut TestContext),
     pub required_features: &'static [FileSystemFeature],

--- a/rust/src/tests/chmod/errno.rs
+++ b/rust/src/tests/chmod/errno.rs
@@ -10,8 +10,10 @@ use crate::test::{FileFlags, FileSystemFeature};
 
 use super::chmod;
 
-crate::test_case! {enotdir => [Regular, Fifo, Block, Char, Socket]}
-/// Returns ENOTDIR if a component of the path prefix is not a directory
+crate::test_case! {
+    /// Returns ENOTDIR if a component of the path prefix is not a directory
+    enotdir => [Regular, Fifo, Block, Char, Socket]
+}
 fn enotdir(ctx: &mut TestContext, f_type: FileType) {
     let not_dir = ctx.create(f_type).unwrap();
     let fake_path = not_dir.join("test");
@@ -20,8 +22,10 @@ fn enotdir(ctx: &mut TestContext, f_type: FileType) {
     assert_eq!(res.unwrap_err(), Errno::ENOTDIR);
 }
 
-crate::test_case! {enametoolong}
-/// chmod returns ENAMETOOLONG if a component of a pathname exceeded {NAME_MAX} characters
+crate::test_case! {
+    /// chmod returns ENAMETOOLONG if a component of a pathname exceeded {NAME_MAX} characters
+    enametoolong
+}
 fn enametoolong(ctx: &mut TestContext) {
     let path = ctx.create_max(FileType::Regular).unwrap();
     let expected_mode = 0o620;

--- a/rust/src/tests/chmod/permission.rs
+++ b/rust/src/tests/chmod/permission.rs
@@ -1,7 +1,7 @@
 use crate::{
     runner::context::FileType,
     test::TestContext,
-    tests::{assert_ctime_changed, assert_ctime_unchanged, chmod::chmod}
+    tests::{assert_ctime_changed, assert_ctime_unchanged, chmod::chmod},
 };
 use nix::{
     sys::stat::{lstat, mode_t, stat, Mode},
@@ -11,7 +11,10 @@ use nix::{
 const FILE_PERMS: mode_t = 0o777;
 
 // chmod/00.t:L24
-crate::test_case! {change_perm => [Regular, Dir, Fifo, Block, Char, Socket]}
+crate::test_case! {
+    /// chmod successfully change permissions
+    change_perm => [Regular, Dir, Fifo, Block, Char, Socket]
+}
 fn change_perm(ctx: &mut TestContext, f_type: FileType) {
     let path = ctx.create(f_type).unwrap();
     let expected_mode = Mode::from_bits_truncate(0o111);
@@ -39,8 +42,11 @@ fn change_perm(ctx: &mut TestContext, f_type: FileType) {
 }
 
 // chmod/00.t:L58
-crate::test_case! {ctime => [Regular, Dir, Fifo, Block, Char, Socket]}
-fn ctime(ctx: &mut TestContext, f_type: FileType) {
+crate::test_case! {
+    /// chmod updates ctime when it succeeds
+    update_ctime => [Regular, Dir, Fifo, Block, Char, Socket]
+}
+fn update_ctime(ctx: &mut TestContext, f_type: FileType) {
     let path = ctx.create(f_type).unwrap();
     assert_ctime_changed(ctx, &path, || {
         chmod(&path, Mode::from_bits_truncate(0o111)).unwrap()
@@ -48,7 +54,10 @@ fn ctime(ctx: &mut TestContext, f_type: FileType) {
 }
 
 // chmod/00.t:L89
-crate::test_case! {failed_chmod_unchanged_ctime => [Regular, Dir, Fifo, Block, Char, Socket]}
+crate::test_case! {
+    /// chmod does not update ctime when it fails
+    failed_chmod_unchanged_ctime => [Regular, Dir, Fifo, Block, Char, Socket]
+}
 fn failed_chmod_unchanged_ctime(ctx: &mut TestContext, f_type: FileType) {
     let path = ctx.create(f_type).unwrap();
     assert_ctime_unchanged(ctx, &path, || {
@@ -58,7 +67,13 @@ fn failed_chmod_unchanged_ctime(ctx: &mut TestContext, f_type: FileType) {
     });
 }
 
-crate::test_case! {clear_isgid_bit}
+crate::test_case! {
+    /// S_ISGID bit shall be cleared upon successful return from chmod of a regular file
+    /// if the calling process does not have appropriate privileges, and if
+    /// the group ID of the file does not match the effective group ID or one of the
+    /// supplementary group IDs
+    clear_isgid_bit
+}
 fn clear_isgid_bit(ctx: &mut TestContext) {
     let path = ctx.create(FileType::Regular).unwrap();
     chmod(&path, Mode::from_bits_truncate(0o0755)).unwrap();


### PR DESCRIPTION
Adds summary with failed, skipped and passed tests counts.
Also continue to run tests after failures, and a verbose flag to display descriptions alongside test names.

Closes #38, closes #50, closes #39