### PR TITLE
Add support for serialized test cases

### DIFF
--- a/book/src/test-declaration.md
+++ b/book/src/test-declaration.md
@@ -105,3 +105,21 @@ For example:
 #[cfg(target_os = "freebsd")]
 mod lchmod;
 ```
+
+## Serialized test cases
+
+Some test cases need functions only available when they are run serialized.
+An example is changing user (`SerializedTestContext::as_user`), which affects the whole process.
+To have access to these functions, the test should be declared with `SerializedTestContext`
+in place of `TestContext`.
+For example:
+
+```rust,ignore
+fn affected_only_create_flags(ctx: &mut SerializedTestContext) {
+    ctx.as_user(Some(Uid::from_raw(65534)), None, || {
+        let path = subdir.join("test1");
+        let file = open(&path, OFlag::O_CREAT | OFlag::O_RDWR, Mode::empty()).unwrap();
+        assert!(posix_fallocate(file, 0, 1).is_ok());
+    });
+} 
+```

--- a/rust/src/test.rs
+++ b/rust/src/test.rs
@@ -18,16 +18,19 @@ pub enum TestError {
 }
 
 /// A single minimal test case.
-pub struct TestCase {
+pub struct TestCase<const SERIALIZED: bool = false> {
     pub name: &'static str,
     pub description: &'static str,
     pub require_root: bool,
-    pub fun: fn(&mut TestContext),
+    pub fun: fn(&mut TestContext<SERIALIZED>),
     pub required_features: &'static [FileSystemFeature],
     pub required_file_flags: &'static [FileFlags],
 }
 
+pub type SerializedTestCase = TestCase<true>;
+
 inventory::collect!(TestCase);
+inventory::collect!(SerializedTestCase);
 
 #[allow(non_camel_case_types)]
 #[derive(

--- a/rust/src/tests/chmod/permission.rs
+++ b/rust/src/tests/chmod/permission.rs
@@ -1,5 +1,5 @@
 use crate::{
-    runner::context::FileType,
+    runner::context::{FileType, SerializedTestContext},
     test::TestContext,
     tests::{assert_ctime_changed, assert_ctime_unchanged, chmod},
 };
@@ -58,7 +58,7 @@ crate::test_case! {
     /// chmod does not update ctime when it fails
     failed_chmod_unchanged_ctime => [Regular, Dir, Fifo, Block, Char, Socket]
 }
-fn failed_chmod_unchanged_ctime(ctx: &mut TestContext, f_type: FileType) {
+fn failed_chmod_unchanged_ctime(ctx: &mut SerializedTestContext, f_type: FileType) {
     let path = ctx.create(f_type).unwrap();
     assert_ctime_unchanged(ctx, &path, || {
         ctx.as_user(Some(Uid::from_raw(65534)), None, || {
@@ -74,7 +74,7 @@ crate::test_case! {
     /// supplementary group IDs
     clear_isgid_bit
 }
-fn clear_isgid_bit(ctx: &mut TestContext) {
+fn clear_isgid_bit(ctx: &mut SerializedTestContext) {
     let path = ctx.create(FileType::Regular).unwrap();
     chmod(&path, Mode::from_bits_truncate(0o0755)).unwrap();
 

--- a/rust/src/tests/mod.rs
+++ b/rust/src/tests/mod.rs
@@ -39,7 +39,7 @@ trait MetadataExt: StdMetadataExt {
 impl<T: StdMetadataExt> MetadataExt for T {}
 
 /// Assert that a certain operation changes the ctime of a file.
-fn assert_ctime_changed<F>(ctx: &mut TestContext, path: &Path, f: F)
+fn assert_ctime_changed<const S: bool, F>(ctx: &mut TestContext<S>, path: &Path, f: F)
 where
     F: FnOnce(),
 {
@@ -54,7 +54,7 @@ where
 }
 
 /// Assert that a certain operation does not change the ctime of a file.
-fn assert_ctime_unchanged<F>(ctx: &TestContext, path: &Path, f: F)
+fn assert_ctime_unchanged<const S: bool, F>(ctx: &TestContext<S>, path: &Path, f: F)
 where
     F: FnOnce(),
 {

--- a/rust/src/tests/posix_fallocate.rs
+++ b/rust/src/tests/posix_fallocate.rs
@@ -8,7 +8,7 @@ use nix::{
 };
 
 use crate::{
-    runner::context::FileType,
+    runner::context::{FileType, SerializedTestContext},
     test::{FileSystemFeature, TestContext},
     tests::{assert_ctime_changed, assert_ctime_unchanged, chmod},
 };
@@ -77,7 +77,7 @@ crate::test_case! {
     /// https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=154873
     affected_only_create_flags, root, FileSystemFeature::PosixFallocate
 }
-fn affected_only_create_flags(ctx: &mut TestContext) {
+fn affected_only_create_flags(ctx: &mut SerializedTestContext) {
     let subdir = ctx.create(FileType::Dir).unwrap();
 
     let path = subdir.join("test");


### PR DESCRIPTION
Adds support for serialized test cases,
which take a `SerializedTestContext` as parameter,
a type alias for `TestContext<true>`.
The context is now composed of a `bool` const generic
(defaults to `false` to not change the syntax) which
specify if the context should run in a serialized context.
As a result,
`SerializedTestContext` provides the same functions as `TestContext`,
plus functions which should be run in a serialized context (e.g `as_user`).

Do you think that it's overengineered?