### PR TITLE
Add default configuration

### DIFF
--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -4,12 +4,12 @@ use crate::test::FileFlags;
 use crate::test::FileSystemFeature;
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 pub struct CommonFeatureConfig {}
 
 /// Configuration for file-system specific features.
 /// Please see the book for more details.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 pub struct FeaturesConfig {
     #[serde(default)]
     pub file_flags: Vec<FileFlags>,
@@ -25,11 +25,19 @@ pub struct SettingsConfig {
     pub naptime: f64,
 }
 
-fn default_naptime() -> f64 {
+impl Default for SettingsConfig {
+    fn default() -> Self {
+        SettingsConfig {
+            naptime: default_naptime(),
+        }
+    }
+}
+
+const fn default_naptime() -> f64 {
     1.0
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 pub struct Config {
     /// File-system features.
     pub features: FeaturesConfig,

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -61,9 +61,10 @@ fn main() -> anyhow::Result<()> {
         .merge(Toml::file(
             args.configuration_file
                 .as_deref()
-                .unwrap_or_else(|| Path::new("pjdfstest.toml")),
+                .unwrap_or_else(|| Path::new("")),
         ))
-        .extract()?;
+        .extract()
+        .unwrap_or_default();
 
     let enabled_features: HashSet<_> = config.features.fs_features.keys().into_iter().collect();
 

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashSet,
     io::{stdout, Write},
     panic::{catch_unwind, set_hook, AssertUnwindSafe},
-    path::{Path, PathBuf},
+    path::PathBuf,
 };
 
 use config::Config;
@@ -57,14 +57,13 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let config: Config = Figment::new()
-        .merge(Toml::file(
-            args.configuration_file
-                .as_deref()
-                .unwrap_or_else(|| Path::new("")),
-        ))
-        .extract()
-        .unwrap_or_default();
+    let config: Config = if let Some(path) = args.configuration_file.as_deref() {
+        Figment::new().merge(Toml::file(path))
+    } else {
+        Figment::new()
+    }
+    .extract()
+    .unwrap_or_default();
 
     let enabled_features: HashSet<_> = config.features.fs_features.keys().into_iter().collect();
 

--- a/rust/src/tests/chmod/permission.rs
+++ b/rust/src/tests/chmod/permission.rs
@@ -49,7 +49,7 @@ crate::test_case! {
 fn update_ctime(ctx: &mut TestContext, f_type: FileType) {
     let path = ctx.create(f_type).unwrap();
     assert_ctime_changed(ctx, &path, || {
-        chmod(&path, Mode::from_bits_truncate(0o111)).unwrap()
+        chmod(&path, Mode::from_bits_truncate(0o111)).unwrap();
     });
 }
 


### PR DESCRIPTION
Remove implicit `pjdfstest.toml` requirement and add empty default config.

Closes #57
