### PR TITLE
Only build a bin, not a lib

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -23,10 +23,6 @@ git = "https://github.com/nix-rust/nix"
 rev = "fb65331"
 features = ["fs", "socket"]
 
-[lib]
-name = "pjdfs_tests"
-path = "src/lib.rs"
-
 [[bin]]
 name = "pjdfstest"
 path = "src/main.rs"

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
-use pjdfs_tests::test::FileFlags;
-use pjdfs_tests::test::FileSystemFeature;
+use crate::test::FileFlags;
+use crate::test::FileSystemFeature;
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,5 +1,0 @@
-mod macros;
-pub mod test;
-pub mod tests;
-//TODO: Export only from the binary?
-mod runner;

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -14,9 +14,13 @@ use gumdrop::Options;
 use once_cell::sync::OnceCell;
 use strum::IntoEnumIterator;
 
-use pjdfs_tests::test::{FileSystemFeature, TestCase, TestContext};
-
+mod macros;
+mod test;
+mod tests;
+mod runner;
 mod config;
+
+use test::{FileSystemFeature, TestCase, TestContext};
 
 struct PanicLocation(u32, u32, String);
 
@@ -152,7 +156,7 @@ fn main() -> anyhow::Result<()> {
             continue;
         }
 
-        let mut context = TestContext::new(&config.settings.naptime);
+        let mut context = TestContext::new(&config.settings);
         //TODO: AssertUnwindSafe should be used with caution
         let mut ctx_wrapper = AssertUnwindSafe(&mut context);
 

--- a/rust/src/test.rs
+++ b/rust/src/test.rs
@@ -3,16 +3,11 @@ use std::fmt::Debug;
 use serde::Deserialize;
 use thiserror::Error;
 
-use crate::runner::context::ContextError;
 pub use crate::runner::context::TestContext;
-
-pub type TestResult = std::result::Result<(), TestError>;
 
 /// Error returned by a test function.
 #[derive(Error, Debug)]
 pub enum TestError {
-    #[error("error while creating file: {0}")]
-    CreateFile(ContextError),
     #[error("error while calling syscall: {0}")]
     Nix(#[from] nix::Error),
 }


### PR DESCRIPTION
I don't think we have any plans for any other crates to use pjdfstest's
library component.  So it's better to build just a single target.  It
will build faster, we'll have fewer problems with private items, and the
compiler will better be able to find dead code.