### PR TITLE
Create temporary directory in CWD or provided path

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -74,7 +74,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
- "libc",
+ "libc 0.2.126 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasi",
 ]
 
@@ -141,6 +141,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
+name = "libc"
+version = "0.2.126"
+source = "git+https://github.com/rust-lang/libc?rev=8dbd2c9#8dbd2c9653b16ba04881edf5caa944e62889245f"
+
+[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,12 +157,12 @@ dependencies = [
 [[package]]
 name = "nix"
 version = "0.24.1"
-source = "git+https://github.com/nix-rust/nix?rev=fb65331#fb65331a559ce3a51640ef6431562eea6cd39725"
+source = "git+https://github.com/nix-rust/nix?rev=b1e1a604a713432773fb6bc8590ff9291c70a0bb#b1e1a604a713432773fb6bc8590ff9291c70a0bb"
 dependencies = [
  "autocfg",
  "bitflags",
  "cfg-if",
- "libc",
+ "libc 0.2.126 (git+https://github.com/rust-lang/libc?rev=8dbd2c9)",
  "memoffset",
  "pin-utils",
 ]
@@ -188,7 +193,7 @@ dependencies = [
  "figment",
  "gumdrop",
  "inventory",
- "libc",
+ "libc 0.2.126 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix",
  "once_cell",
  "paste",
@@ -230,7 +235,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc",
+ "libc 0.2.126 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha",
  "rand_core",
 ]
@@ -339,7 +344,7 @@ checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
  "cfg-if",
  "fastrand",
- "libc",
+ "libc 0.2.126 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall",
  "remove_dir_all",
  "winapi",

--- a/rust/src/runner/context.rs
+++ b/rust/src/runner/context.rs
@@ -16,7 +16,7 @@ use std::{
     time::Duration,
 };
 use strum_macros::EnumIter;
-use tempfile::{tempdir, TempDir};
+use tempfile::{tempdir_in, TempDir};
 use thiserror::Error;
 
 use crate::{config::SettingsConfig, test::TestError};
@@ -78,8 +78,8 @@ impl DerefMut for SerializedTestContext {
 }
 
 impl SerializedTestContext {
-    pub fn new(settings: &SettingsConfig) -> Self {
-        Self(TestContext::new(settings))
+    pub fn new<P: AsRef<Path>>(settings: &SettingsConfig, base_dir: P) -> Self {
+        Self(TestContext::new(settings, base_dir))
     }
 
     //TODO: Maybe better as a macro? unwrap?
@@ -121,9 +121,9 @@ impl SerializedTestContext {
 }
 
 impl TestContext {
-    pub fn new(settings: &SettingsConfig) -> Self {
+    pub fn new<P: AsRef<Path>>(settings: &SettingsConfig, base_dir: P) -> Self {
         let naptime = Duration::from_secs_f64(settings.naptime);
-        let temp_dir = tempdir().unwrap();
+        let temp_dir = tempdir_in(base_dir).unwrap();
         TestContext { naptime, temp_dir }
     }
 


### PR DESCRIPTION
Add an optional argument to specify where the directory should be created, or create it in CWD otherwise.

Closes #59