### PR TITLE
Eliminate user 65535

### DIFF
--- a/tests/chmod/00.t
+++ b/tests/chmod/00.t
@@ -123,14 +123,14 @@ done
 # successful return from chmod().
 
 expect 0 create ${n0} 0755
-expect 0 chown ${n0} 65535 65535
-expect 0 -u 65535 -g 65535 chmod ${n0} 02755
+expect 0 chown ${n0} 65534 65534
+expect 0 -u 65534 -g 65534 chmod ${n0} 02755
 expect 02755 stat ${n0} mode
-expect 0 -u 65535 -g 65535 chmod ${n0} 0755
+expect 0 -u 65534 -g 65534 chmod ${n0} 0755
 expect 0755 stat ${n0} mode
 
 todo FreeBSD "S_ISGID should be removed and chmod(2) should success and FreeBSD returns EPERM."
-expect 0 -u 65535 -g 65534 chmod ${n0} 02755
+expect 0 -u 65534 -g 65533 chmod ${n0} 02755
 expect 0755 stat ${n0} mode
 
 expect 0 unlink ${n0}

--- a/tests/mkdir/00.t
+++ b/tests/mkdir/00.t
@@ -38,16 +38,16 @@ expect 0 rmdir ${n0}
 # POSIX: The directory's user ID shall be set to the process' effective user ID.
 # The directory's group ID shall be set to the group ID of the parent directory
 # or to the effective group ID of the process.
-expect 0 chown . 65535 65535
-expect 0 -u 65535 -g 65535 mkdir ${n0} 0755
-expect 65535,65535 lstat ${n0} uid,gid
+expect 0 chown . 65534 65534
+expect 0 -u 65534 -g 65534 mkdir ${n0} 0755
+expect 65534,65534 lstat ${n0} uid,gid
 expect 0 rmdir ${n0}
-expect 0 -u 65535 -g 65534 mkdir ${n0} 0755
-expect "65535,6553[45]" lstat ${n0} uid,gid
+expect 0 -u 65534 -g 65533 mkdir ${n0} 0755
+expect "65534,6553[34]" lstat ${n0} uid,gid
 expect 0 rmdir ${n0}
 expect 0 chmod . 0777
-expect 0 -u 65534 -g 65533 mkdir ${n0} 0755
-expect "65534,6553[35]" lstat ${n0} uid,gid
+expect 0 -u 65533 -g 65532 mkdir ${n0} 0755
+expect "65533,6553[24]" lstat ${n0} uid,gid
 expect 0 rmdir ${n0}
 
 # POSIX: Upon successful completion, mkdir() shall mark for update the st_atime,

--- a/tests/mkfifo/00.t
+++ b/tests/mkfifo/00.t
@@ -38,16 +38,18 @@ expect 0 unlink ${n0}
 # POSIX: The FIFO's user ID shall be set to the process' effective user ID.
 # The FIFO's group ID shall be set to the group ID of the parent directory or to
 # the effective group ID of the process.
-expect 0 chown . 65535 65535
-expect 0 -u 65535 -g 65535 mkfifo ${n0} 0755
-expect 65535,65535 lstat ${n0} uid,gid
+expect 0 chown . 65534 65534
+expect 0 -u 65534 -g 65534 mkfifo ${n0} 0755
+expect 65534,65534 lstat ${n0} uid,gid
 expect 0 unlink ${n0}
-expect 0 -u 65535 -g 65534 mkfifo ${n0} 0755
-expect "65535,6553[45]" lstat ${n0} uid,gid
-expect 0 unlink ${n0}
-expect 0 chmod . 0777
+
 expect 0 -u 65534 -g 65533 mkfifo ${n0} 0755
-expect "65534,6553[35]" lstat ${n0} uid,gid
+expect "65534,6553[34]" lstat ${n0} uid,gid
+expect 0 unlink ${n0}
+
+expect 0 chmod . 0777
+expect 0 -u 65533 -g 65532 mkfifo ${n0} 0755
+expect "65533,6553[24]" lstat ${n0} uid,gid
 expect 0 unlink ${n0}
 
 # POSIX: Upon successful completion, mkfifo() shall mark for update the

--- a/tests/mknod/00.t
+++ b/tests/mknod/00.t
@@ -40,16 +40,16 @@ expect 0 unlink ${n0}
 # POSIX: The FIFO's user ID shall be set to the process' effective user ID.
 # The FIFO's group ID shall be set to the group ID of the parent directory or to
 # the effective group ID of the process.
-expect 0 chown . 65535 65535
-expect 0 -u 65535 -g 65535 mknod ${n0} f 0755 0 0
-expect 65535,65535 lstat ${n0} uid,gid
+expect 0 chown . 65534 65534
+expect 0 -u 65534 -g 65534 mknod ${n0} f 0755 0 0
+expect 65534,65534 lstat ${n0} uid,gid
 expect 0 unlink ${n0}
-expect 0 -u 65535 -g 65534 mknod ${n0} f 0755 0 0
-expect "65535,6553[45]" lstat ${n0} uid,gid
+expect 0 -u 65534 -g 65533 mknod ${n0} f 0755 0 0
+expect "65534,6553[34]" lstat ${n0} uid,gid
 expect 0 unlink ${n0}
 expect 0 chmod . 0777
-expect 0 -u 65534 -g 65533 mknod ${n0} f 0755 0 0
-expect "65534,6553[35]" lstat ${n0} uid,gid
+expect 0 -u 65533 -g 65532 mknod ${n0} f 0755 0 0
+expect "65533,6553[24]" lstat ${n0} uid,gid
 expect 0 unlink ${n0}
 
 # POSIX: Upon successful completion, mknod() shall mark for update the

--- a/tests/open/00.t
+++ b/tests/open/00.t
@@ -42,16 +42,16 @@ expect 0 unlink ${n0}
 # of the file shall be set to the effective user ID of the process; the group ID
 # of the file shall be set to the group ID of the file's parent directory or to
 # the effective group ID of the process [...]
-expect 0 chown . 65535 65535
-expect 0 -u 65535 -g 65535 open ${n0} O_CREAT,O_WRONLY 0644
-expect 65535,65535 lstat ${n0} uid,gid
+expect 0 chown . 65534 65534
+expect 0 -u 65534 -g 65534 open ${n0} O_CREAT,O_WRONLY 0644
+expect 65534,65534 lstat ${n0} uid,gid
 expect 0 unlink ${n0}
-expect 0 -u 65535 -g 65534 open ${n0} O_CREAT,O_WRONLY 0644
-expect "65535,6553[45]" lstat ${n0} uid,gid
+expect 0 -u 65534 -g 65533 open ${n0} O_CREAT,O_WRONLY 0644
+expect "65534,6553[34]" lstat ${n0} uid,gid
 expect 0 unlink ${n0}
 expect 0 chmod . 0777
-expect 0 -u 65534 -g 65533 open ${n0} O_CREAT,O_WRONLY 0644
-expect "65534,6553[35]" lstat ${n0} uid,gid
+expect 0 -u 65533 -g 65532 open ${n0} O_CREAT,O_WRONLY 0644
+expect "65533,6553[24]" lstat ${n0} uid,gid
 expect 0 unlink ${n0}
 
 # Update parent directory ctime/mtime if file didn't exist.


### PR DESCRIPTION
Only two unprivileged users are needed: 65534 and 65533 suffice.

chmod/00.t
This test only needs one unprivileged user.

{mkfifo,open,mkdir,mknod}/00.t
These tests all related to the group ID of a newly created file.  They
need two unprivileged users and three groups.