### PR TITLE
Add file builder API

### DIFF
--- a/rust/src/runner/context.rs
+++ b/rust/src/runner/context.rs
@@ -289,13 +289,13 @@ impl FileBuilder {
     /// Create a file builder.
     pub fn new<P: AsRef<Path>>(file_type: FileType, base_path: &P) -> Self {
         Self {
-            file_type: file_type.clone(),
             path: base_path.as_ref().to_path_buf(),
             random_name: true,
-            mode: match file_type {
+            mode: match &file_type {
                 FileType::Dir => Mode::from_bits_truncate(0o755),
                 _ => Mode::from_bits_truncate(0o644),
             },
+            file_type,
         }
     }
 
@@ -354,7 +354,7 @@ impl FileBuilder {
     /// Join `name` to the base path.
     /// An absolute path can also be provided, in this case it completely replaces the path.
     pub fn name<P: AsRef<Path>>(mut self, name: P) -> Self {
-        self.path = self.path.join(name.as_ref());
+        self.path.push(name.as_ref());
         self.random_name = false;
         self
     }
@@ -500,7 +500,7 @@ mod tests {
             let ctx = TestContext::new(&settings, &tmpdir.path());
             let name = "testing";
             let expected_mode = 0o725;
-            let (path, file) = ctx
+            let (path, _file) = ctx
                 .new_file(ft)
                 .mode(expected_mode)
                 .name(name)

--- a/rust/src/runner/context.rs
+++ b/rust/src/runner/context.rs
@@ -19,6 +19,7 @@ use nix::{sys::stat::FileFlag, unistd::chflags};
 
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use std::{
+    fs::create_dir_all,
     ops::{Deref, DerefMut},
     os::unix::{fs::symlink, prelude::RawFd},
     panic::{catch_unwind, resume_unwind, UnwindSafe},
@@ -46,16 +47,7 @@ pub enum FileType {
 
 impl FileType {
     pub const fn privileged(&self) -> bool {
-        match self {
-            FileType::Regular => false,
-            FileType::Dir => false,
-            //TODO: Not sure for FIFO
-            FileType::Fifo => false,
-            FileType::Block => true,
-            FileType::Char => true,
-            FileType::Socket => false,
-            FileType::Symlink(..) => false,
-        }
+        matches!(self, FileType::Block | FileType::Char)
     }
 }
 
@@ -124,7 +116,6 @@ impl SerializedTestContext {
             setegid(original_egid).unwrap();
         }
 
-        //TODO: Should we resume?
         if let Err(e) = res {
             resume_unwind(e)
         }
@@ -132,6 +123,7 @@ impl SerializedTestContext {
 }
 
 impl TestContext {
+    /// Create a new test context.
     pub fn new<P: AsRef<Path>>(settings: &SettingsConfig, base_dir: P) -> Self {
         let naptime = Duration::from_secs_f64(settings.naptime);
         let temp_dir = tempdir_in(base_dir).unwrap();
@@ -144,60 +136,32 @@ impl TestContext {
 
     /// Create a regular file and open it.
     pub fn create_file(
-        &mut self,
+        &self,
         oflag: OFlag,
-        mode: Option<Mode>,
+        mode: Option<nix::sys::stat::mode_t>,
     ) -> Result<(PathBuf, RawFd), TestError> {
-        let path = self.create(FileType::Regular)?;
-        let file = open(&path, oflag, mode.unwrap_or_else(Mode::empty))?;
-        Ok((path, file))
+        let mut file = self.new_file(FileType::Regular);
+        if let Some(mode) = mode {
+            file = file.mode(mode);
+        }
+        Ok(file.open(oflag)?)
     }
 
-    /// Create a file in a temp folder with a random name.
-    pub fn create(&mut self, f_type: FileType) -> Result<PathBuf, TestError> {
-        let path = self.temp_dir.path().join(
-            thread_rng()
-                .sample_iter(&Alphanumeric)
-                .take(NUM_RAND_CHARS)
-                .map(char::from)
-                .collect::<String>(),
-        );
-
-        let mode = Mode::from_bits_truncate(0o644);
-
-        match f_type {
-            FileType::Regular => open(&path, OFlag::O_CREAT, mode).and_then(close),
-            FileType::Dir => mkdir(&path, Mode::from_bits_truncate(0o755)),
-            FileType::Fifo => mkfifo(&path, mode),
-            FileType::Block => mknod(&path, SFlag::S_IFBLK, mode, 0),
-            FileType::Char => mknod(&path, SFlag::S_IFCHR, mode, 0),
-            FileType::Socket => {
-                let fd = socket(
-                    nix::sys::socket::AddressFamily::Unix,
-                    nix::sys::socket::SockType::Stream,
-                    SockFlag::empty(),
-                    None,
-                )?;
-                let sockaddr = UnixAddr::new(&path)?;
-                bind(fd, &sockaddr)
-            }
-            //TODO: error type?
-            FileType::Symlink(target) => symlink(
-                target.as_deref().unwrap_or_else(|| Path::new("test")),
-                &path,
-            )
-            .map_err(|e| nix::Error::try_from(e).unwrap_or(nix::errno::Errno::UnknownErrno)),
-        }?;
-
-        Ok(path)
+    /// Return a file builder.
+    pub fn new_file(&self, ft: FileType) -> FileBuilder {
+        FileBuilder::new(ft, &self.base_path())
     }
 
-    pub fn create_max(&mut self, f_type: FileType) -> Result<PathBuf, TestError> {
-        //TODO: const?
-        let max_name_len =
-            pathconf(self.temp_dir.path(), nix::unistd::PathconfVar::NAME_MAX)?.unwrap();
+    /// Create a file with a random name.
+    pub fn create(&self, f_type: FileType) -> Result<PathBuf, TestError> {
+        Ok(self.new_file(f_type).create()?)
+    }
 
-        let path = self.temp_dir.path().join(
+    /// Create a file whose name length is _PC_NAME_MAX.
+    pub fn create_name_max(&self, f_type: FileType) -> Result<PathBuf, TestError> {
+        let max_name_len = pathconf(self.base_path(), nix::unistd::PathconfVar::NAME_MAX)?.unwrap();
+
+        let file = self.new_file(f_type).name(
             thread_rng()
                 .sample_iter(&Alphanumeric)
                 .take(max_name_len as usize)
@@ -205,31 +169,56 @@ impl TestContext {
                 .collect::<String>(),
         );
 
-        let mode = Mode::from_bits_truncate(0o644);
+        Ok(file.create()?)
+    }
 
-        match f_type {
-            FileType::Regular => open(&path, OFlag::O_CREAT, mode).and_then(close),
-            FileType::Dir => mkdir(&path, Mode::from_bits_truncate(0o755)),
-            FileType::Fifo => mkfifo(&path, mode),
-            FileType::Block => mknod(&path, SFlag::S_IFBLK, mode, 0),
-            FileType::Char => mknod(&path, SFlag::S_IFCHR, mode, 0),
-            FileType::Socket => {
-                let fd = socket(
-                    nix::sys::socket::AddressFamily::Unix,
-                    nix::sys::socket::SockType::Stream,
-                    SockFlag::empty(),
-                    None,
-                )?;
-                let sockaddr = UnixAddr::new(&path)?;
-                bind(fd, &sockaddr)
-            }
-            //TODO: error type?
-            FileType::Symlink(target) => symlink(
-                target.as_deref().unwrap_or_else(|| Path::new("test")),
-                &path,
-            )
-            .map_err(|e| nix::Error::try_from(e).unwrap_or(nix::errno::Errno::UnknownErrno)),
-        }?;
+    /// Create a file whose path length is _PC_PATH_MAX.
+    pub fn create_path_max(&self, f_type: FileType) -> Result<PathBuf, TestError> {
+        let max_name_len =
+            pathconf(self.base_path(), nix::unistd::PathconfVar::NAME_MAX)?.unwrap() as usize;
+        let component_len = max_name_len / 2;
+
+        // - 1 for null char
+        let max_path_len =
+            pathconf(self.base_path(), nix::unistd::PathconfVar::PATH_MAX)?.unwrap() as usize - 1;
+
+        let mut path = self.base_path().to_owned();
+        let initial_path_len = path.to_string_lossy().len();
+        let remaining_chars = max_path_len - initial_path_len;
+
+        let parts: Vec<_> = (0..remaining_chars / component_len)
+            .into_iter()
+            .map(|_| {
+                thread_rng()
+                    .sample_iter(&Alphanumeric)
+                    .take(component_len - 1)
+                    .map(char::from)
+                    .collect::<String>()
+            })
+            .collect();
+
+        let remaining_chars = remaining_chars % component_len - 1;
+        if remaining_chars > 0 {
+            path.extend(parts);
+
+            create_dir_all(&path).unwrap();
+
+            path.push(
+                thread_rng()
+                    .sample_iter(&Alphanumeric)
+                    .take(remaining_chars)
+                    .map(char::from)
+                    .collect::<String>(),
+            );
+        } else {
+            path.extend(&parts[..parts.len() - 1]);
+
+            create_dir_all(&path).unwrap();
+
+            path.push(&parts[parts.len() - 1]);
+        }
+
+        self.new_file(f_type).name(&path).create()?;
 
         Ok(path)
     }
@@ -283,6 +272,246 @@ impl Drop for TestContext {
                     let _ = chflags(entry.path(), FileFlag::empty());
                 }
             }
+        }
+    }
+}
+
+/// Allows to create a file using builder pattern.
+#[derive(Debug)]
+pub struct FileBuilder {
+    file_type: FileType,
+    path: PathBuf,
+    random_name: bool,
+    mode: Mode,
+}
+
+impl FileBuilder {
+    /// Create a file builder.
+    pub fn new<P: AsRef<Path>>(file_type: FileType, base_path: &P) -> Self {
+        Self {
+            file_type: file_type.clone(),
+            path: base_path.as_ref().to_path_buf(),
+            random_name: true,
+            mode: match file_type {
+                FileType::Dir => Mode::from_bits_truncate(0o755),
+                _ => Mode::from_bits_truncate(0o644),
+            },
+        }
+    }
+
+    /// Create the file according to the provided information.
+    pub fn create(self) -> nix::Result<PathBuf> {
+        let mode = self.mode;
+        let mut path = self.path;
+        if self.random_name {
+            path = path.join(
+                thread_rng()
+                    .sample_iter(&Alphanumeric)
+                    .take(NUM_RAND_CHARS)
+                    .map(char::from)
+                    .collect::<String>(),
+            );
+        }
+
+        match self.file_type {
+            FileType::Regular => open(&path, OFlag::O_CREAT, mode).and_then(close),
+            FileType::Dir => mkdir(&path, mode),
+            FileType::Fifo => mkfifo(&path, mode),
+            FileType::Block => mknod(&path, SFlag::S_IFBLK, mode, 0),
+            FileType::Char => mknod(&path, SFlag::S_IFCHR, mode, 0),
+            FileType::Socket => {
+                let fd = socket(
+                    nix::sys::socket::AddressFamily::Unix,
+                    nix::sys::socket::SockType::Stream,
+                    SockFlag::empty(),
+                    None,
+                )?;
+                let sockaddr = UnixAddr::new(&path)?;
+                bind(fd, &sockaddr)
+            }
+            FileType::Symlink(target) => symlink(
+                target.as_deref().unwrap_or_else(|| Path::new("test")),
+                &path,
+            )
+            .map_err(|e| nix::Error::try_from(e).unwrap_or(nix::errno::Errno::UnknownErrno)),
+        }?;
+
+        Ok(path)
+    }
+
+    /// Create the file according to the provided information and open it.
+    pub fn open(self, oflags: OFlag) -> nix::Result<(PathBuf, RawFd)> {
+        let path = self.create()?;
+        Ok((path.clone(), open(&path, oflags, Mode::empty())?))
+    }
+
+    /// Change file mode.
+    pub fn mode(mut self, mode: nix::sys::stat::mode_t) -> Self {
+        self.mode = Mode::from_bits_truncate(mode);
+        self
+    }
+
+    /// Join `name` to the base path.
+    /// An absolute path can also be provided, in this case it completely replaces the path.
+    pub fn name<P: AsRef<Path>>(mut self, name: P) -> Self {
+        self.path = self.path.join(name.as_ref());
+        self.random_name = false;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nix::{errno::Errno, fcntl::OFlag, sys::stat::Mode, unistd::pathconf};
+    use tempfile::TempDir;
+    use walkdir::WalkDir;
+
+    use crate::{
+        config::SettingsConfig,
+        utils::{chmod, ALLPERMS},
+    };
+
+    use super::{FileType, TestContext};
+
+    #[test]
+    fn create() {
+        for ft in [
+            FileType::Regular,
+            FileType::Dir,
+            FileType::Fifo,
+            FileType::Socket,
+            FileType::Symlink(None),
+        ] {
+            let settings = SettingsConfig { naptime: 0. };
+            let tempdir = TempDir::new().unwrap();
+            let ctx = TestContext::new(&settings, tempdir.path());
+
+            assert!(ctx.temp_dir.path().starts_with(tempdir.path()));
+
+            let parent_content = WalkDir::new(tempdir.path())
+                .min_depth(1)
+                .into_iter()
+                .collect::<Vec<_>>();
+            assert_eq!(parent_content.len(), 1);
+            assert!(parent_content[0].as_ref().unwrap().file_type().is_dir());
+            assert_eq!(
+                parent_content[0].as_ref().unwrap().path(),
+                ctx.temp_dir.path()
+            );
+            assert_eq!(
+                WalkDir::new(ctx.temp_dir.path())
+                    .min_depth(1)
+                    .into_iter()
+                    .count(),
+                0
+            );
+
+            let file = ctx.create(ft.clone()).unwrap();
+            let parent_content: Vec<_> = WalkDir::new(tempdir.path())
+                .min_depth(1)
+                .max_depth(1)
+                .into_iter()
+                .filter_map(|e| e.ok())
+                .collect();
+            assert_eq!(parent_content.len(), 1);
+
+            let content: Vec<_> = WalkDir::new(ctx.temp_dir.path())
+                .min_depth(1)
+                .max_depth(1)
+                .into_iter()
+                .filter_map(|e| e.ok())
+                .collect();
+            assert_eq!(content.len(), 1);
+            assert_eq!(content[0].path(), &file);
+
+            let file_stat = nix::sys::stat::lstat(&file).unwrap();
+            assert_eq!(
+                file_stat.st_mode & nix::libc::S_IFMT,
+                match ft {
+                    FileType::Dir => nix::libc::S_IFDIR,
+                    FileType::Fifo => nix::libc::S_IFIFO,
+                    FileType::Regular => nix::libc::S_IFREG,
+                    FileType::Socket => nix::libc::S_IFSOCK,
+                    FileType::Symlink(..) => nix::libc::S_IFLNK,
+                    _ => unimplemented!(),
+                }
+            )
+        }
+    }
+
+    #[test]
+    fn name_max() {
+        let tmpdir = TempDir::new().unwrap();
+        let settings = SettingsConfig { naptime: 0. };
+        let ctx = TestContext::new(&settings, &tmpdir.path());
+        let file = ctx.create_name_max(FileType::Regular).unwrap();
+        let name_len = file.file_name().unwrap().to_string_lossy().len();
+
+        let max_len = pathconf(ctx.base_path(), nix::unistd::PathconfVar::NAME_MAX)
+            .unwrap()
+            .unwrap();
+        assert_eq!(name_len, max_len as usize);
+        let mut invalid = file.clone();
+        invalid.set_file_name(invalid.file_name().unwrap().to_string_lossy().into_owned() + "x");
+
+        assert_eq!(
+            chmod(&invalid, Mode::empty()).unwrap_err(),
+            Errno::ENAMETOOLONG
+        );
+    }
+
+    #[test]
+    fn path_max() {
+        let tmpdir = TempDir::new().unwrap();
+        let settings = SettingsConfig { naptime: 0. };
+        let ctx = TestContext::new(&settings, &tmpdir.path());
+        let file = ctx.create_path_max(FileType::Regular).unwrap();
+        let path_len = file.to_string_lossy().len();
+
+        // including null char
+        let max_len = pathconf(ctx.base_path(), nix::unistd::PathconfVar::PATH_MAX)
+            .unwrap()
+            .unwrap()
+            - 1;
+        assert_eq!(path_len, max_len as usize);
+        let mut invalid = file.clone();
+        invalid.set_file_name(invalid.file_name().unwrap().to_string_lossy().into_owned() + "x");
+
+        assert_eq!(
+            chmod(&invalid, Mode::empty()).unwrap_err(),
+            Errno::ENAMETOOLONG
+        );
+    }
+
+    #[test]
+    fn new_file() {
+        let current_umask = nix::sys::stat::umask(Mode::from_bits_truncate(ALLPERMS));
+        nix::sys::stat::umask(current_umask);
+
+        for ft in [
+            FileType::Regular,
+            FileType::Dir,
+            // FileType::Fifo,
+            // FileType::Socket,
+            // FileType::Symlink(None),
+        ] {
+            let tmpdir = TempDir::new().unwrap();
+            let settings = SettingsConfig { naptime: 0. };
+            let ctx = TestContext::new(&settings, &tmpdir.path());
+            let name = "testing";
+            let expected_mode = 0o725;
+            let (path, file) = ctx
+                .new_file(ft)
+                .mode(expected_mode)
+                .name(name)
+                .open(OFlag::O_RDONLY)
+                .unwrap();
+
+            assert_eq!(path.file_name().unwrap().to_string_lossy(), name);
+
+            let file_stat = nix::sys::stat::stat(&path).unwrap();
+            let actual_mode = file_stat.st_mode & ALLPERMS;
+            assert_eq!(actual_mode, expected_mode & (!current_umask.bits()));
         }
     }
 }

--- a/rust/src/tests/chmod/errno.rs
+++ b/rust/src/tests/chmod/errno.rs
@@ -25,7 +25,7 @@ crate::test_case! {
     enametoolong
 }
 fn enametoolong(ctx: &mut TestContext) {
-    let path = ctx.create_max(FileType::Regular).unwrap();
+    let path = ctx.create_name_max(FileType::Regular).unwrap();
     let expected_mode = 0o620;
     chmod(&path, Mode::from_bits_truncate(expected_mode)).unwrap();
     let actual_mode = stat(&path).unwrap().st_mode;

--- a/rust/src/tests/chmod/permission.rs
+++ b/rust/src/tests/chmod/permission.rs
@@ -2,14 +2,12 @@ use crate::{
     runner::context::{FileType, SerializedTestContext},
     test::TestContext,
     tests::{assert_ctime_changed, assert_ctime_unchanged},
-    utils::chmod,
+    utils::{chmod, ALLPERMS},
 };
 use nix::{
     sys::stat::{lstat, mode_t, stat, Mode},
     unistd::{chown, Gid, Uid},
 };
-
-const FILE_PERMS: mode_t = 0o777;
 
 // chmod/00.t:L24
 crate::test_case! {
@@ -24,7 +22,7 @@ fn change_perm(ctx: &mut TestContext, f_type: FileType) {
 
     let actual_mode = stat(&path).unwrap().st_mode;
 
-    assert_eq!(actual_mode & FILE_PERMS, expected_mode.bits());
+    assert_eq!(actual_mode & ALLPERMS, expected_mode.bits());
 
     // We test if it applies through symlinks
     let symlink_path = ctx.create(FileType::Symlink(Some(path.clone()))).unwrap();
@@ -35,11 +33,11 @@ fn change_perm(ctx: &mut TestContext, f_type: FileType) {
 
     let actual_mode = stat(&path).unwrap().st_mode;
     let actual_sym_mode = stat(&symlink_path).unwrap().st_mode;
-    assert_eq!(actual_mode & FILE_PERMS, expected_mode.bits());
-    assert_eq!(actual_sym_mode & FILE_PERMS, expected_mode.bits());
+    assert_eq!(actual_mode & ALLPERMS, expected_mode.bits());
+    assert_eq!(actual_sym_mode & ALLPERMS, expected_mode.bits());
 
     let actual_link_mode = lstat(&symlink_path).unwrap().st_mode;
-    assert_eq!(link_mode & FILE_PERMS, actual_link_mode & FILE_PERMS);
+    assert_eq!(link_mode & ALLPERMS, actual_link_mode & ALLPERMS);
 }
 
 // chmod/00.t:L58

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -17,3 +17,5 @@ pub fn lchmod<P: ?Sized + nix::NixPath>(path: &P, mode: nix::sys::stat::Mode) ->
         nix::sys::stat::FchmodatFlags::NoFollowSymlink,
     )
 }
+
+pub const ALLPERMS: nix::sys::stat::mode_t = 0o777;


### PR DESCRIPTION
Add file builder API to conveniently create a file with a custom name/mode.
Also add tests for the context functions.

Close #82 
Close #76