### PR TITLE
Add umask switching

### DIFF
--- a/book/src/test-declaration.md
+++ b/book/src/test-declaration.md
@@ -108,11 +108,12 @@ mod lchmod;
 
 ## Serialized test cases
 
-Some test cases need functions only available when they are run serialized.
-An example is changing user (`SerializedTestContext::as_user`), which affects the whole process.
+Some test cases need functions only available when they are run serialized, especially when they affect the whole process.
+An example is changing user (`SerializedTestContext::as_user`).
 To have access to these functions, the test should be declared with a `SerializedTestContext`
 parameter in place of `TestContext` 
 and the `serialized` keyword should be prepended before features.
+umask is automatically set to 0 for serialized test cases.
 
 For example:
 

--- a/book/src/test-declaration.md
+++ b/book/src/test-declaration.md
@@ -113,7 +113,6 @@ An example is changing user (`SerializedTestContext::as_user`).
 To have access to these functions, the test should be declared with a `SerializedTestContext`
 parameter in place of `TestContext` 
 and the `serialized` keyword should be prepended before features.
-umask is automatically set to 0 for serialized test cases.
 
 For example:
 

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -12,7 +12,10 @@ use figment::{
     Figment,
 };
 use gumdrop::Options;
-use nix::unistd::{Group, Uid, User};
+use nix::{
+    sys::stat::{umask, Mode},
+    unistd::{Group, Uid, User},
+};
 use once_cell::sync::OnceCell;
 use strum::IntoEnumIterator;
 
@@ -106,6 +109,8 @@ fn main() -> anyhow::Result<()> {
                 })
         })
         .collect();
+
+    umask(Mode::empty());
 
     let (failed_count, skipped_count, success_count) =
         run_test_cases(&test_cases, args.verbose, &config, base_dir)?;

--- a/rust/src/runner/context.rs
+++ b/rust/src/runner/context.rs
@@ -88,7 +88,6 @@ pub struct TestContext {
 pub struct SerializedTestContext {
     ctx: TestContext,
     auth_entries: DummyAuthEntries,
-    original_umask: Mode,
 }
 
 impl Deref for SerializedTestContext {
@@ -114,7 +113,6 @@ impl SerializedTestContext {
         Self {
             ctx: TestContext::new(settings, base_dir),
             auth_entries: DummyAuthEntries::new(entries.to_vec()),
-            original_umask: umask(Mode::empty()),
         }
     }
 
@@ -167,6 +165,7 @@ impl SerializedTestContext {
         }
     }
 
+    /// Execute the function with another umask.
     pub fn with_umask<F>(&self, mask: mode_t, f: F)
     where
         F: FnOnce(),
@@ -185,7 +184,7 @@ impl SerializedTestContext {
 
 impl Drop for SerializedTestContext {
     fn drop(&mut self) {
-        umask(self.original_umask);
+        umask(Mode::empty());
     }
 }
 


### PR DESCRIPTION
Add support for switching umask in serialized tests, restoring the original one in the context destructor.
Should I set the value to 0 only on serialized tests, or on all tests? I didn't find a case where it should cause any problem, but I'm maybe missing something. 