### PR TITLE
Correctly set the pjdfstest user's shell

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -24,7 +24,7 @@ task:
     - fetch https://sh.rustup.rs -o rustup.sh
     - sh rustup.sh -y --profile=minimal
     - |
-      cat <<EOF | adduser -w none -f -
+      cat <<EOF | adduser -w none -S -f -
       pjdfstest::::::Dummy User for pjdfstest:/nonexistent:/sbin/nologin:
       EOF
     - . $HOME/.cargo/env

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -50,7 +50,7 @@ It is also possible to specify other users with the configuration file.
 #### FreeBSD
 
 ```bash
-cat <<EOF | adduser -w none -f -
+cat <<EOF | adduser -w none -S -f -
 pjdfstest::::::Dummy User for pjdfstest:/nonexistent:/sbin/nologin:
 EOF
 ```


### PR DESCRIPTION
Without "-S", adduser helpfully "fixes" /sbin/nologin to /bin/sh