### PR TITLE
Add mkdir, mkfifo and mknod tests

### DIFF
--- a/rust/src/tests/mkdir.rs
+++ b/rust/src/tests/mkdir.rs
@@ -9,7 +9,7 @@ use crate::runner::context::{SerializedTestContext, TestContext};
 
 use super::{assert_times_changed, ATIME, CTIME, MTIME};
 use super::mksyscalls::{
-    permission_bits_from_mode_builder,
+    assert_perms_from_mode_and_umask,
     assert_uid_gid,
 };
 
@@ -20,7 +20,7 @@ crate::test_case! {
     permission_bits_from_mode, serialized
 }
 fn permission_bits_from_mode(ctx: &mut SerializedTestContext) {
-    permission_bits_from_mode_builder(ctx, mkdir, FileType::is_dir);
+    assert_perms_from_mode_and_umask(ctx, mkdir, FileType::is_dir);
 }
 
 crate::test_case! {

--- a/rust/src/tests/mkdir.rs
+++ b/rust/src/tests/mkdir.rs
@@ -2,13 +2,15 @@ use std::{fs::metadata, os::unix::prelude::PermissionsExt};
 
 use nix::{
     sys::stat::{lstat, mode_t, Mode},
-    unistd::{mkdir, Gid, Uid, User},
+    unistd::{chown, mkdir, Gid, Uid, User},
 };
 
 use crate::{
     runner::context::{SerializedTestContext, TestContext},
     utils::{chmod, ALLPERMS},
 };
+
+use super::assert_time_changed;
 
 crate::test_case! {
     /// POSIX: The file permission bits of the new directory shall be initialized from
@@ -22,7 +24,10 @@ fn permission_bits_from_mode(ctx: &mut SerializedTestContext) {
         assert!(mkdir(&path, Mode::from_bits_truncate(mkdir_mode)).is_ok());
         let meta = metadata(&path).unwrap();
         assert!(meta.is_dir());
-        assert_eq!(meta.permissions().mode() & ALLPERMS, expected_mode);
+        assert_eq!(
+            meta.permissions().mode() as mode_t & ALLPERMS,
+            expected_mode
+        );
     }
 
     fn assert_perm_umask(ctx: &SerializedTestContext, mkdir_mode: mode_t, umask: mode_t) {
@@ -49,8 +54,6 @@ crate::test_case! {
     dir_uid_gid_eq_euid_egid, serialized, root
 }
 fn dir_uid_gid_eq_euid_egid(ctx: &mut SerializedTestContext) {
-    chmod(ctx.base_path(), Mode::from_bits_truncate(0o777)).unwrap();
-
     fn assert_uid_gid(ctx: &SerializedTestContext, user: &User, gid: Option<Gid>) {
         let path = ctx.gen_path();
         ctx.as_user(user, gid.map(|g| vec![g]).as_deref(), || {
@@ -63,21 +66,42 @@ fn dir_uid_gid_eq_euid_egid(ctx: &mut SerializedTestContext) {
             ..
         } = lstat(&path).unwrap();
         assert_eq!(file_uid, user.uid.as_raw());
-        assert_eq!(file_gid, gid.unwrap_or(user.gid).as_raw());
+        let egid = gid.unwrap_or(user.gid).as_raw();
+        let nix::sys::stat::FileStat {
+            st_gid: parent_gid, ..
+        } = lstat(ctx.base_path()).unwrap();
+        assert!(file_gid == egid || file_gid == parent_gid);
     }
 
     let user = User::from_uid(Uid::effective()).unwrap().unwrap();
     assert_uid_gid(ctx, &user, None);
 
     let user = ctx.get_new_user();
+    // To check that the entry gid is either parent gid or egid
+    chown(ctx.base_path(), Some(user.uid), Some(user.gid)).unwrap();
+
     let (other_user, group) = ctx.get_new_entry();
     assert_uid_gid(ctx, &user, Some(group.gid));
+
+    chmod(ctx.base_path(), Mode::from_bits_truncate(ALLPERMS)).unwrap();
 
     let group = ctx.get_new_group();
     assert_uid_gid(ctx, &other_user, Some(group.gid));
 }
 
-crate::test_case! {changed_time_fields_success}
+crate::test_case! {
+    /// POSIX: Upon successful completion, mkdir() shall mark for update the st_atime,
+    /// st_ctime, and st_mtime fields of the directory. Also, the st_ctime and
+    /// st_mtime fields of the directory that contains the new entry shall be marked
+    /// for update.
+    changed_time_fields_success
+}
 fn changed_time_fields_success(ctx: &mut TestContext) {
-    todo!()
+    let uid = Uid::effective();
+    let gid = Gid::effective();
+    chown(ctx.base_path(), Some(uid), Some(gid)).unwrap();
+    let path = ctx.gen_path();
+    assert_time_changed(ctx, ctx.base_path(), &path, true, true, false, || {
+        mkdir(&path, Mode::from_bits_truncate(0o755)).unwrap();
+    });
 }

--- a/rust/src/tests/mkdir.rs
+++ b/rust/src/tests/mkdir.rs
@@ -1,0 +1,83 @@
+use std::{fs::metadata, os::unix::prelude::PermissionsExt};
+
+use nix::{
+    sys::stat::{lstat, mode_t, Mode},
+    unistd::{mkdir, Gid, Uid, User},
+};
+
+use crate::{
+    runner::context::{SerializedTestContext, TestContext},
+    utils::{chmod, ALLPERMS},
+};
+
+crate::test_case! {
+    /// POSIX: The file permission bits of the new directory shall be initialized from
+    /// mode. These file permission bits of the mode argument shall be modified by the
+    /// process' file creation mask.
+    permission_bits_from_mode, serialized
+}
+fn permission_bits_from_mode(ctx: &mut SerializedTestContext) {
+    fn assert_perm(ctx: &SerializedTestContext, mkdir_mode: mode_t, expected_mode: mode_t) {
+        let path = ctx.gen_path();
+        assert!(mkdir(&path, Mode::from_bits_truncate(mkdir_mode)).is_ok());
+        let meta = metadata(&path).unwrap();
+        assert!(meta.is_dir());
+        assert_eq!(meta.permissions().mode() & ALLPERMS, expected_mode);
+    }
+
+    fn assert_perm_umask(ctx: &SerializedTestContext, mkdir_mode: mode_t, umask: mode_t) {
+        ctx.with_umask(umask, || {
+            assert_perm(ctx, mkdir_mode, mkdir_mode & (!umask));
+        })
+    }
+
+    fn assert_perm_mode(ctx: &SerializedTestContext, mkdir_mode: mode_t) {
+        assert_perm(ctx, mkdir_mode, mkdir_mode);
+    }
+
+    assert_perm_mode(ctx, 0o755);
+    assert_perm_mode(ctx, 0o151);
+    assert_perm_umask(ctx, 0o151, 0o77);
+    assert_perm_umask(ctx, 0o345, 0o70);
+    assert_perm_umask(ctx, 0o501, 0o345);
+}
+
+crate::test_case! {
+    /// POSIX: The directory's user ID shall be set to the process' effective user ID.
+    /// The directory's group ID shall be set to the group ID of the parent directory
+    /// or to the effective group ID of the process.
+    dir_uid_gid_eq_euid_egid, serialized, root
+}
+fn dir_uid_gid_eq_euid_egid(ctx: &mut SerializedTestContext) {
+    chmod(ctx.base_path(), Mode::from_bits_truncate(0o777)).unwrap();
+
+    fn assert_uid_gid(ctx: &SerializedTestContext, user: &User, gid: Option<Gid>) {
+        let path = ctx.gen_path();
+        ctx.as_user(user, gid.map(|g| vec![g]).as_deref(), || {
+            mkdir(&path, Mode::from_bits_truncate(0o755)).unwrap();
+        });
+
+        let nix::sys::stat::FileStat {
+            st_uid: file_uid,
+            st_gid: file_gid,
+            ..
+        } = lstat(&path).unwrap();
+        assert_eq!(file_uid, user.uid.as_raw());
+        assert_eq!(file_gid, gid.unwrap_or(user.gid).as_raw());
+    }
+
+    let user = User::from_uid(Uid::effective()).unwrap().unwrap();
+    assert_uid_gid(ctx, &user, None);
+
+    let user = ctx.get_new_user();
+    let (other_user, group) = ctx.get_new_entry();
+    assert_uid_gid(ctx, &user, Some(group.gid));
+
+    let group = ctx.get_new_group();
+    assert_uid_gid(ctx, &other_user, Some(group.gid));
+}
+
+crate::test_case! {changed_time_fields_success}
+fn changed_time_fields_success(ctx: &mut TestContext) {
+    todo!()
+}

--- a/rust/src/tests/mkdir.rs
+++ b/rust/src/tests/mkdir.rs
@@ -7,10 +7,9 @@ use nix::{
 
 use crate::{
     runner::context::{SerializedTestContext, TestContext},
+    tests::TimeAssertion,
     utils::{chmod, ALLPERMS},
 };
-
-use super::assert_time_changed;
 
 crate::test_case! {
     /// POSIX: The file permission bits of the new directory shall be initialized from
@@ -100,8 +99,15 @@ fn changed_time_fields_success(ctx: &mut TestContext) {
     let uid = Uid::effective();
     let gid = Gid::effective();
     chown(ctx.base_path(), Some(uid), Some(gid)).unwrap();
+
     let path = ctx.gen_path();
-    assert_time_changed(ctx, ctx.base_path(), &path, true, true, false, || {
+
+    TimeAssertion::new(&ctx.base_path(), false, || {
         mkdir(&path, Mode::from_bits_truncate(0o755)).unwrap();
-    });
+    })
+    .add_after(&path)
+    .atime()
+    .ctime()
+    .mtime()
+    .assert(ctx);
 }

--- a/rust/src/tests/mkdir.rs
+++ b/rust/src/tests/mkdir.rs
@@ -10,7 +10,7 @@ use crate::runner::context::{SerializedTestContext, TestContext};
 use super::{assert_times_changed, ATIME, CTIME, MTIME};
 use super::mksyscalls::{
     permission_bits_from_mode_builder,
-    uid_gid_eq_euid_or_parent_uid_egid_builder,
+    assert_uid_gid,
 };
 
 crate::test_case! {
@@ -30,7 +30,7 @@ crate::test_case! {
     uid_gid_eq_euid_egid, serialized, root
 }
 fn uid_gid_eq_euid_egid(ctx: &mut SerializedTestContext) {
-    uid_gid_eq_euid_or_parent_uid_egid_builder(ctx, mkdir);
+    assert_uid_gid(ctx, mkdir);
 }
 
 crate::test_case! {

--- a/rust/src/tests/mkdir.rs
+++ b/rust/src/tests/mkdir.rs
@@ -1,14 +1,12 @@
-use std::{fs::metadata, os::unix::prelude::PermissionsExt};
+use std::fs::FileType;
 
-use nix::{
-    sys::stat::{lstat, mode_t, Mode},
-    unistd::{chown, mkdir, Gid, Uid, User},
-};
+use nix::unistd::mkdir;
 
-use crate::{
-    runner::context::{SerializedTestContext, TestContext},
-    tests::TimeAssertion,
-    utils::{chmod, ALLPERMS},
+use crate::runner::context::{SerializedTestContext, TestContext};
+
+use super::mksyscalls::{
+    changed_time_fields_success_builder, permission_bits_from_mode_builder,
+    uid_gid_eq_euid_or_parent_uid_egid_builder,
 };
 
 crate::test_case! {
@@ -18,74 +16,17 @@ crate::test_case! {
     permission_bits_from_mode, serialized
 }
 fn permission_bits_from_mode(ctx: &mut SerializedTestContext) {
-    fn assert_perm(ctx: &SerializedTestContext, mkdir_mode: mode_t, expected_mode: mode_t) {
-        let path = ctx.gen_path();
-        assert!(mkdir(&path, Mode::from_bits_truncate(mkdir_mode)).is_ok());
-        let meta = metadata(&path).unwrap();
-        assert!(meta.is_dir());
-        assert_eq!(
-            meta.permissions().mode() as mode_t & ALLPERMS,
-            expected_mode
-        );
-    }
-
-    fn assert_perm_umask(ctx: &SerializedTestContext, mkdir_mode: mode_t, umask: mode_t) {
-        ctx.with_umask(umask, || {
-            assert_perm(ctx, mkdir_mode, mkdir_mode & (!umask));
-        })
-    }
-
-    fn assert_perm_mode(ctx: &SerializedTestContext, mkdir_mode: mode_t) {
-        assert_perm(ctx, mkdir_mode, mkdir_mode);
-    }
-
-    assert_perm_mode(ctx, 0o755);
-    assert_perm_mode(ctx, 0o151);
-    assert_perm_umask(ctx, 0o151, 0o77);
-    assert_perm_umask(ctx, 0o345, 0o70);
-    assert_perm_umask(ctx, 0o501, 0o345);
+    permission_bits_from_mode_builder(ctx, mkdir, FileType::is_dir);
 }
 
 crate::test_case! {
     /// POSIX: The directory's user ID shall be set to the process' effective user ID.
     /// The directory's group ID shall be set to the group ID of the parent directory
     /// or to the effective group ID of the process.
-    dir_uid_gid_eq_euid_egid, serialized, root
+    uid_gid_eq_euid_egid, serialized, root
 }
-fn dir_uid_gid_eq_euid_egid(ctx: &mut SerializedTestContext) {
-    fn assert_uid_gid(ctx: &SerializedTestContext, user: &User, gid: Option<Gid>) {
-        let path = ctx.gen_path();
-        ctx.as_user(user, gid.map(|g| vec![g]).as_deref(), || {
-            mkdir(&path, Mode::from_bits_truncate(0o755)).unwrap();
-        });
-
-        let nix::sys::stat::FileStat {
-            st_uid: file_uid,
-            st_gid: file_gid,
-            ..
-        } = lstat(&path).unwrap();
-        assert_eq!(file_uid, user.uid.as_raw());
-        let egid = gid.unwrap_or(user.gid).as_raw();
-        let nix::sys::stat::FileStat {
-            st_gid: parent_gid, ..
-        } = lstat(ctx.base_path()).unwrap();
-        assert!(file_gid == egid || file_gid == parent_gid);
-    }
-
-    let user = User::from_uid(Uid::effective()).unwrap().unwrap();
-    assert_uid_gid(ctx, &user, None);
-
-    let user = ctx.get_new_user();
-    // To check that the entry gid is either parent gid or egid
-    chown(ctx.base_path(), Some(user.uid), Some(user.gid)).unwrap();
-
-    let (other_user, group) = ctx.get_new_entry();
-    assert_uid_gid(ctx, &user, Some(group.gid));
-
-    chmod(ctx.base_path(), Mode::from_bits_truncate(ALLPERMS)).unwrap();
-
-    let group = ctx.get_new_group();
-    assert_uid_gid(ctx, &other_user, Some(group.gid));
+fn uid_gid_eq_euid_egid(ctx: &mut SerializedTestContext) {
+    uid_gid_eq_euid_or_parent_uid_egid_builder(ctx, mkdir);
 }
 
 crate::test_case! {
@@ -96,18 +37,5 @@ crate::test_case! {
     changed_time_fields_success
 }
 fn changed_time_fields_success(ctx: &mut TestContext) {
-    let uid = Uid::effective();
-    let gid = Gid::effective();
-    chown(ctx.base_path(), Some(uid), Some(gid)).unwrap();
-
-    let path = ctx.gen_path();
-
-    TimeAssertion::new(&ctx.base_path(), false, || {
-        mkdir(&path, Mode::from_bits_truncate(0o755)).unwrap();
-    })
-    .add_after(&path)
-    .atime()
-    .ctime()
-    .mtime()
-    .assert(ctx);
+    changed_time_fields_success_builder(ctx, mkdir);
 }

--- a/rust/src/tests/mkfifo.rs
+++ b/rust/src/tests/mkfifo.rs
@@ -10,7 +10,7 @@ use crate::runner::context::{SerializedTestContext, TestContext};
 use super::{assert_times_changed, ATIME, CTIME, MTIME};
 use super::mksyscalls::{
     permission_bits_from_mode_builder,
-    uid_gid_eq_euid_or_parent_uid_egid_builder,
+    assert_uid_gid,
 };
 
 crate::test_case! {
@@ -30,7 +30,7 @@ crate::test_case! {
     uid_gid_eq_euid_egid, serialized, root
 }
 fn uid_gid_eq_euid_egid(ctx: &mut SerializedTestContext) {
-    uid_gid_eq_euid_or_parent_uid_egid_builder(ctx, mkfifo);
+    assert_uid_gid(ctx, mkfifo);
 }
 
 crate::test_case! {

--- a/rust/src/tests/mkfifo.rs
+++ b/rust/src/tests/mkfifo.rs
@@ -1,0 +1,41 @@
+use std::{fs::FileType, os::unix::fs::FileTypeExt};
+
+use nix::unistd::mkfifo;
+
+use crate::runner::context::{SerializedTestContext, TestContext};
+
+use super::mksyscalls::{
+    changed_time_fields_success_builder, permission_bits_from_mode_builder,
+    uid_gid_eq_euid_or_parent_uid_egid_builder,
+};
+
+crate::test_case! {
+    /// POSIX: The file permission bits of the new FIFO shall be initialized from
+    /// mode. The file permission bits of the mode argument shall be modified by the
+    /// process' file creation mask.
+    permission_bits_from_mode, serialized
+}
+fn permission_bits_from_mode(ctx: &mut SerializedTestContext) {
+    permission_bits_from_mode_builder(ctx, mkfifo, FileType::is_fifo);
+}
+
+crate::test_case! {
+    /// POSIX: The FIFO's user ID shall be set to the process' effective user ID.
+    /// The FIFO's group ID shall be set to the group ID of the parent directory or to
+    /// the effective group ID of the process.
+    uid_gid_eq_euid_egid, serialized, root
+}
+fn uid_gid_eq_euid_egid(ctx: &mut SerializedTestContext) {
+    uid_gid_eq_euid_or_parent_uid_egid_builder(ctx, mkfifo);
+}
+
+crate::test_case! {
+    /// POSIX: Upon successful completion, mkfifo() shall mark for update the st_atime,
+    /// st_ctime, and st_mtime fields of the file. Also, the st_ctime and
+    /// st_mtime fields of the directory that contains the new entry shall be marked
+    /// for update.
+    changed_time_fields_success
+}
+fn changed_time_fields_success(ctx: &mut TestContext) {
+    changed_time_fields_success_builder(ctx, mkfifo);
+}

--- a/rust/src/tests/mkfifo.rs
+++ b/rust/src/tests/mkfifo.rs
@@ -1,11 +1,15 @@
 use std::{fs::FileType, os::unix::fs::FileTypeExt};
 
-use nix::unistd::mkfifo;
+use nix::{
+    sys::stat::Mode,
+    unistd::mkfifo
+};
 
 use crate::runner::context::{SerializedTestContext, TestContext};
 
+use super::{assert_times_changed, ATIME, CTIME, MTIME};
 use super::mksyscalls::{
-    changed_time_fields_success_builder, permission_bits_from_mode_builder,
+    permission_bits_from_mode_builder,
     uid_gid_eq_euid_or_parent_uid_egid_builder,
 };
 
@@ -37,5 +41,12 @@ crate::test_case! {
     changed_time_fields_success
 }
 fn changed_time_fields_success(ctx: &mut TestContext) {
-    changed_time_fields_success_builder(ctx, mkfifo);
+    let path = ctx.gen_path();
+
+    assert_times_changed()
+        .path(ctx.base_path(), CTIME | MTIME)
+        .paths(ctx.base_path(), &path, ATIME | CTIME | MTIME)
+        .execute(ctx, false, || {
+            mkfifo(&path, Mode::from_bits_truncate(0o600)).unwrap();
+        });
 }

--- a/rust/src/tests/mkfifo.rs
+++ b/rust/src/tests/mkfifo.rs
@@ -9,7 +9,7 @@ use crate::runner::context::{SerializedTestContext, TestContext};
 
 use super::{assert_times_changed, ATIME, CTIME, MTIME};
 use super::mksyscalls::{
-    permission_bits_from_mode_builder,
+    assert_perms_from_mode_and_umask,
     assert_uid_gid,
 };
 
@@ -20,7 +20,7 @@ crate::test_case! {
     permission_bits_from_mode, serialized
 }
 fn permission_bits_from_mode(ctx: &mut SerializedTestContext) {
-    permission_bits_from_mode_builder(ctx, mkfifo, FileType::is_fifo);
+    assert_perms_from_mode_and_umask(ctx, mkfifo, FileType::is_fifo);
 }
 
 crate::test_case! {

--- a/rust/src/tests/mknod.rs
+++ b/rust/src/tests/mknod.rs
@@ -6,7 +6,7 @@ use crate::runner::context::{SerializedTestContext, TestContext};
 
 use super::{assert_times_changed, ATIME, CTIME, MTIME};
 use super::mksyscalls::{
-    permission_bits_from_mode_builder,
+    assert_perms_from_mode_and_umask,
     assert_uid_gid,
 };
 
@@ -22,7 +22,7 @@ crate::test_case! {
     permission_bits_from_mode, serialized
 }
 fn permission_bits_from_mode(ctx: &mut SerializedTestContext) {
-    permission_bits_from_mode_builder(ctx, mknod_wrapper, FileType::is_fifo);
+    assert_perms_from_mode_and_umask(ctx, mknod_wrapper, FileType::is_fifo);
 }
 
 crate::test_case! {

--- a/rust/src/tests/mknod.rs
+++ b/rust/src/tests/mknod.rs
@@ -1,0 +1,46 @@
+use std::{fs::FileType, os::unix::fs::FileTypeExt, path::Path};
+
+use nix::sys::stat::{mknod, Mode, SFlag};
+
+use crate::runner::context::{SerializedTestContext, TestContext};
+
+use super::mksyscalls::{
+    changed_time_fields_success_builder, permission_bits_from_mode_builder,
+    uid_gid_eq_euid_or_parent_uid_egid_builder,
+};
+
+/// TODO: Shouldn't test it for other types?
+fn mknod_wrapper(path: &Path, mode: Mode) -> nix::Result<()> {
+    mknod(path, SFlag::S_IFIFO, mode, 0)
+}
+
+crate::test_case! {
+    /// POSIX: The file permission bits of the new FIFO shall be initialized from
+    /// mode. The file permission bits of the mode argument shall be modified by the
+    /// process' file creation mask.
+    permission_bits_from_mode, serialized
+}
+fn permission_bits_from_mode(ctx: &mut SerializedTestContext) {
+    permission_bits_from_mode_builder(ctx, mknod_wrapper, FileType::is_fifo);
+}
+
+crate::test_case! {
+    /// POSIX: The FIFO's user ID shall be set to the process' effective user ID.
+    /// The FIFO's group ID shall be set to the group ID of the parent directory or to
+    /// the effective group ID of the process.
+    uid_gid_eq_euid_egid, serialized, root
+}
+fn uid_gid_eq_euid_egid(ctx: &mut SerializedTestContext) {
+    uid_gid_eq_euid_or_parent_uid_egid_builder(ctx, mknod_wrapper);
+}
+
+crate::test_case! {
+    /// POSIX: Upon successful completion, mkfifo() shall mark for update the st_atime,
+    /// st_ctime, and st_mtime fields of the file. Also, the st_ctime and
+    /// st_mtime fields of the directory that contains the new entry shall be marked
+    /// for update.
+    changed_time_fields_success
+}
+fn changed_time_fields_success(ctx: &mut TestContext) {
+    changed_time_fields_success_builder(ctx, mknod_wrapper);
+}

--- a/rust/src/tests/mknod.rs
+++ b/rust/src/tests/mknod.rs
@@ -4,8 +4,9 @@ use nix::sys::stat::{mknod, Mode, SFlag};
 
 use crate::runner::context::{SerializedTestContext, TestContext};
 
+use super::{assert_times_changed, ATIME, CTIME, MTIME};
 use super::mksyscalls::{
-    changed_time_fields_success_builder, permission_bits_from_mode_builder,
+    permission_bits_from_mode_builder,
     uid_gid_eq_euid_or_parent_uid_egid_builder,
 };
 
@@ -42,5 +43,12 @@ crate::test_case! {
     changed_time_fields_success
 }
 fn changed_time_fields_success(ctx: &mut TestContext) {
-    changed_time_fields_success_builder(ctx, mknod_wrapper);
+    let path = ctx.gen_path();
+
+    assert_times_changed()
+        .path(ctx.base_path(), CTIME | MTIME)
+        .paths(ctx.base_path(), &path, ATIME | CTIME | MTIME)
+        .execute(ctx, false, || {
+            mknod_wrapper(&path, Mode::from_bits_truncate(0o644)).unwrap();
+        });
 }

--- a/rust/src/tests/mknod.rs
+++ b/rust/src/tests/mknod.rs
@@ -7,7 +7,7 @@ use crate::runner::context::{SerializedTestContext, TestContext};
 use super::{assert_times_changed, ATIME, CTIME, MTIME};
 use super::mksyscalls::{
     permission_bits_from_mode_builder,
-    uid_gid_eq_euid_or_parent_uid_egid_builder,
+    assert_uid_gid,
 };
 
 /// TODO: Shouldn't test it for other types?
@@ -32,7 +32,7 @@ crate::test_case! {
     uid_gid_eq_euid_egid, serialized, root
 }
 fn uid_gid_eq_euid_egid(ctx: &mut SerializedTestContext) {
-    uid_gid_eq_euid_or_parent_uid_egid_builder(ctx, mknod_wrapper);
+    assert_uid_gid(ctx, mknod_wrapper);
 }
 
 crate::test_case! {

--- a/rust/src/tests/mksyscalls.rs
+++ b/rust/src/tests/mksyscalls.rs
@@ -1,0 +1,144 @@
+//! Builder functions for `mk`-family syscalls tests.
+
+use std::{
+    fs::{metadata, FileType},
+    os::unix::prelude::PermissionsExt,
+    path::Path,
+};
+
+use nix::{
+    sys::stat::{lstat, mode_t, Mode},
+    unistd::{chown, Gid, Uid, User},
+};
+
+use crate::{
+    runner::context::{SerializedTestContext, TestContext},
+    utils::{chmod, ALLPERMS},
+};
+
+use super::TimeAssertion;
+
+pub(super) fn permission_bits_from_mode_builder<F, T, C>(
+    ctx: &mut SerializedTestContext,
+    f: F,
+    f_type_check: C,
+) where
+    F: Fn(&Path, Mode) -> nix::Result<T>,
+    C: Fn(&FileType) -> bool,
+{
+    fn assert_perm<F, T, C>(
+        ctx: &SerializedTestContext,
+        mode: mode_t,
+        expected_mode: mode_t,
+        f: F,
+        f_type_check: C,
+    ) where
+        F: Fn(&Path, Mode) -> nix::Result<T>,
+        C: Fn(&FileType) -> bool,
+    {
+        let path = ctx.gen_path();
+        assert!(f(&path, Mode::from_bits_truncate(mode)).is_ok());
+        let meta = metadata(&path).unwrap();
+        assert!(f_type_check(&meta.file_type()));
+        assert_eq!(
+            meta.permissions().mode() as mode_t & ALLPERMS,
+            expected_mode
+        );
+    }
+
+    fn assert_perm_umask<F, T, C>(
+        ctx: &SerializedTestContext,
+        mode: mode_t,
+        umask: mode_t,
+        f: F,
+        check: C,
+    ) where
+        F: Fn(&Path, Mode) -> nix::Result<T>,
+        C: Fn(&FileType) -> bool,
+    {
+        ctx.with_umask(umask, || {
+            assert_perm(ctx, mode, mode & (!umask), f, check);
+        })
+    }
+
+    fn assert_perm_mode<F, T, C>(ctx: &SerializedTestContext, mode: mode_t, f: F, check: C)
+    where
+        F: Fn(&Path, Mode) -> nix::Result<T>,
+        C: Fn(&FileType) -> bool,
+    {
+        assert_perm(ctx, mode, mode, f, check);
+    }
+
+    assert_perm_mode(ctx, 0o755, &f, &f_type_check);
+    assert_perm_mode(ctx, 0o151, &f, &f_type_check);
+    assert_perm_umask(ctx, 0o151, 0o77, &f, &f_type_check);
+    assert_perm_umask(ctx, 0o345, 0o70, &f, &f_type_check);
+    assert_perm_umask(ctx, 0o501, 0o345, f, f_type_check);
+}
+
+pub(super) fn uid_gid_eq_euid_or_parent_uid_egid_builder<F, T>(
+    ctx: &mut SerializedTestContext,
+    f: F,
+) where
+    F: Fn(&Path, Mode) -> nix::Result<T>,
+{
+    fn assert_uid_gid<F, T>(ctx: &SerializedTestContext, user: &User, gid: Option<Gid>, f: F)
+    where
+        F: Fn(&Path, Mode) -> nix::Result<T>,
+    {
+        let path = ctx.gen_path();
+        ctx.as_user(user, gid.map(|g| vec![g]).as_deref(), || {
+            //TODO: Original tests use 755 but we shouldn't we test 644 for non-dir files?
+            f(&path, Mode::from_bits_truncate(0o755)).unwrap();
+        });
+
+        let nix::sys::stat::FileStat {
+            st_uid: file_uid,
+            st_gid: file_gid,
+            ..
+        } = lstat(&path).unwrap();
+        assert_eq!(file_uid, user.uid.as_raw());
+
+        let egid = gid.unwrap_or(user.gid).as_raw();
+        let nix::sys::stat::FileStat {
+            st_gid: parent_gid, ..
+        } = lstat(ctx.base_path()).unwrap();
+        assert!(file_gid == egid || file_gid == parent_gid);
+    }
+
+    let user = User::from_uid(Uid::effective()).unwrap().unwrap();
+    assert_uid_gid(ctx, &user, None, &f);
+
+    let user = ctx.get_new_user();
+    // To check that the entry gid is either parent gid or egid
+    chown(ctx.base_path(), Some(user.uid), Some(user.gid)).unwrap();
+
+    let (other_user, group) = ctx.get_new_entry();
+    assert_uid_gid(ctx, &user, Some(group.gid), &f);
+
+    chmod(ctx.base_path(), Mode::from_bits_truncate(ALLPERMS)).unwrap();
+
+    let group = ctx.get_new_group();
+    assert_uid_gid(ctx, &other_user, Some(group.gid), f);
+}
+
+pub(super) fn changed_time_fields_success_builder<F, T>(ctx: &mut TestContext, f: F)
+where
+    F: Fn(&Path, Mode) -> nix::Result<T>,
+{
+    let uid = Uid::effective();
+    let gid = Gid::effective();
+    chown(ctx.base_path(), Some(uid), Some(gid)).unwrap();
+
+    let path = ctx.gen_path();
+
+    TimeAssertion::new(&ctx.base_path(), false, || {
+        //TODO: Original tests use 755 but we shouldn't we test 644 for non-dir files?
+        f(&path, Mode::from_bits_truncate(0o755)).unwrap();
+    })
+    .add_after(&path)
+    .atime()
+    .ctime()
+    .mtime()
+    .assert(ctx);
+}

--- a/rust/src/tests/mksyscalls.rs
+++ b/rust/src/tests/mksyscalls.rs
@@ -16,9 +16,10 @@ use crate::{
     utils::{chmod, ALLPERMS},
 };
 
-/// Assert that the created entry gets its permission bits from the mode provided to the function
-/// negated by the process file creation mask (umask), and its file type equal the expected one.
-pub(super) fn permission_bits_from_mode_builder<F, T, C>(
+/// Assert that the created entry gets its permission bits from the mode
+/// provided to the function negated by the process's file creation mask
+/// (umask), and its file type is equal to the expected one.
+pub(super) fn assert_perms_from_mode_and_umask<F, T, C>(
     ctx: &mut SerializedTestContext,
     f: F,
     f_type_check: C,

--- a/rust/src/tests/mod.rs
+++ b/rust/src/tests/mod.rs
@@ -18,6 +18,9 @@ pub mod chmod;
 pub mod ftruncate;
 pub mod link;
 pub mod mkdir;
+pub mod mkfifo;
+pub mod mknod;
+mod mksyscalls;
 pub mod posix_fallocate;
 pub mod rename;
 pub mod rmdir;
@@ -115,7 +118,7 @@ fn birthtime_ts(path: &Path) -> TimeSpec {
 
 #[derive(Debug)]
 #[must_use]
-/// Builder to create a time metadata assertion, which compares metadata of one file before to many files after.
+/// Builder to create a time metadata assertion, which compares metadata of one file `before` to many files `after`.
 struct TimeAssertion<'a, F> {
     before_path: &'a Path,
     after_paths: Vec<&'a Path>,
@@ -130,7 +133,7 @@ impl<'a, F> TimeAssertion<'a, F>
 where
     F: FnOnce(),
 {
-    /// Return a new builder with the provided path being the before and after compared paths.
+    /// Return a new builder with the provided path being the `before` compared path and added to the `after` compared paths.
     /// Comparision will be an equality check if `equal` is true, or an ordering one if it is false.
     pub fn new<P: AsRef<Path>>(path: &'a P, equal: bool, fun: F) -> Self {
         Self {
@@ -144,7 +147,7 @@ where
         }
     }
 
-    /// Return a new builder with the provided path being the before compared path.
+    /// Return a new builder with the provided path being the `before` compared path.
     /// Comparision will be an equality check if `equal` is true, or an ordering one if it is false.
     pub fn new_with_paths<P: AsRef<Path>>(before_path: &'a P, equal: bool, fun: F) -> Self {
         Self {
@@ -158,7 +161,7 @@ where
         }
     }
 
-    /// Add a path for which metadata should be compared after.
+    /// Add a path to the `after` compared paths.
     pub fn add_after<P: AsRef<Path>>(mut self, path: &'a P) -> Self {
         self.after_paths.push(path.as_ref());
         self
@@ -182,7 +185,7 @@ where
         self
     }
 
-    /// Build the assertion and asserts that "before" metadata is either equal or before the "after" metadata.
+    /// Build the assertion and asserts that `before` metadata is either equal or before the `after` metadata.
     pub fn assert(self, ctx: &TestContext) {
         if !(self.atime || self.ctime || self.mtime) || self.after_paths.is_empty() {
             unimplemented!()

--- a/rust/src/tests/mod.rs
+++ b/rust/src/tests/mod.rs
@@ -127,7 +127,7 @@ struct TimeAssertion<'a, F> {
     ctime: bool,
     mtime: bool,
     equal: bool,
-    follow_symlink: bool,
+    no_follow_symlink: bool,
     fun: F,
 }
 
@@ -144,7 +144,7 @@ where
             atime: false,
             ctime: false,
             mtime: false,
-            follow_symlink: false,
+            no_follow_symlink: false,
             equal,
             fun,
         }
@@ -159,7 +159,7 @@ where
             atime: false,
             ctime: false,
             mtime: false,
-            follow_symlink: false,
+            no_follow_symlink: false,
             equal,
             fun,
         }
@@ -189,8 +189,9 @@ where
         self
     }
 
-    pub fn follow_symlink(mut self) -> Self {
-        self.follow_symlink = true;
+    /// Get metadata without following symlinks.
+    pub fn no_follow_symlink(mut self) -> Self {
+        self.no_follow_symlink = true;
         self
     }
 
@@ -200,7 +201,7 @@ where
             unimplemented!()
         }
 
-        let get_metadata = if self.follow_symlink {
+        let get_metadata = if self.no_follow_symlink {
             symlink_metadata
         } else {
             metadata
@@ -265,7 +266,7 @@ where
 {
     TimeAssertion::new(&path, true, f)
         .ctime()
-        .follow_symlink()
+        .no_follow_symlink()
         .assert(ctx)
 }
 

--- a/rust/src/tests/mod.rs
+++ b/rust/src/tests/mod.rs
@@ -119,7 +119,8 @@ fn birthtime_ts(path: &Path) -> TimeSpec {
 
 #[derive(Debug)]
 #[must_use]
-/// Builder to create a time metadata assertion, which compares metadata of one file `before` to many files `after`.
+/// Builder to create a time metadata assertion,
+/// which compares metadata of one file `before` to many files `after`.
 struct TimeAssertion<'a, F> {
     before_path: &'a Path,
     after_paths: Vec<&'a Path>,
@@ -135,7 +136,8 @@ impl<'a, F> TimeAssertion<'a, F>
 where
     F: FnOnce(),
 {
-    /// Return a new builder with the provided path being the `before` compared path and added to the `after` compared paths.
+    /// Return a new builder with the provided path being the `before` compared path
+    /// and added to the `after` compared paths.
     /// Comparision will be an equality check if `equal` is true, or an ordering one if it is false.
     pub fn new<P: AsRef<Path>>(path: &'a P, equal: bool, fun: F) -> Self {
         Self {
@@ -195,7 +197,8 @@ where
         self
     }
 
-    /// Build the assertion and asserts that `before` metadata is either equal or before the `after` metadata.
+    /// Build the assertion and asserts that `before` metadata
+    /// is either equal or before the `after` metadata.
     pub fn assert(self, ctx: &TestContext) {
         if !(self.atime || self.ctime || self.mtime) || self.after_paths.is_empty() {
             unimplemented!()

--- a/rust/src/tests/mod.rs
+++ b/rust/src/tests/mod.rs
@@ -227,7 +227,7 @@ where
     TimeAssertion::new(&path, false, f).ctime().assert(ctx)
 }
 
-/// Assert that a certain operation changes the ctime of a file.
+/// Assert that a certain operation changes the mtime of a file.
 fn assert_mtime_changed<F>(ctx: &TestContext, path: &Path, f: F)
 where
     F: FnOnce(),
@@ -243,7 +243,7 @@ where
     TimeAssertion::new(&path, true, f).ctime().assert(ctx)
 }
 
-/// Assert that a certain operation does not change the ctime of a file.
+/// Assert that a certain operation does not change the mtime of a file.
 fn assert_mtime_unchanged<F>(ctx: &TestContext, path: &Path, f: F)
 where
     F: FnOnce(),

--- a/rust/src/tests/mod.rs
+++ b/rust/src/tests/mod.rs
@@ -18,6 +18,7 @@ use crate::test::TestContext;
 pub mod chmod;
 pub mod ftruncate;
 pub mod link;
+pub mod mkdir;
 pub mod posix_fallocate;
 pub mod rename;
 pub mod rmdir;

--- a/rust/src/tests/mod.rs
+++ b/rust/src/tests/mod.rs
@@ -1,4 +1,5 @@
 use std::fs::symlink_metadata;
+use std::ops::{BitAnd, BitOr};
 use std::os::unix::fs::MetadataExt as StdMetadataExt;
 
 use std::{fs::metadata, path::Path};
@@ -29,11 +30,36 @@ pub mod symlink;
 pub mod unlink;
 pub mod utimensat;
 
-#[derive(Debug, PartialEq, PartialOrd)]
-struct TimeMetadata {
-    atime_ts: Option<TimeSpec>,
-    ctime_ts: Option<TimeSpec>,
-    mtime_ts: Option<TimeSpec>,
+/// Argument to set which fields should be compared for [`TimeAssertion::path`].
+#[derive(Debug, Clone, Copy)]
+struct TimestampField(u32);
+
+impl TimestampField {
+    pub const ATIME: TimestampField = TimestampField(0b001);
+    pub const CTIME: TimestampField = TimestampField(0b010);
+    pub const MTIME: TimestampField = TimestampField(0b100);
+}
+
+impl PartialEq<u32> for TimestampField {
+    fn eq(&self, other: &u32) -> bool {
+        self.0 == *other
+    }
+}
+
+impl BitAnd for TimestampField {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        Self(self.0 & rhs.0)
+    }
+}
+
+impl BitOr for TimestampField {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0 | rhs.0)
+    }
 }
 
 /// A handy extention to std::os::unix::fs::MetadataExt
@@ -54,14 +80,6 @@ trait MetadataExt: StdMetadataExt {
     /// fractional component.
     fn mtime_ts(&self) -> TimeSpec {
         TimeSpec::new(self.mtime(), self.mtime_nsec())
-    }
-
-    fn time_meta(&self, atime: bool, ctime: bool, mtime: bool) -> TimeMetadata {
-        TimeMetadata {
-            atime_ts: atime.then(|| self.atime_ts()),
-            ctime_ts: ctime.then(|| self.ctime_ts()),
-            mtime_ts: mtime.then(|| self.mtime_ts()),
-        }
     }
 }
 
@@ -120,122 +138,102 @@ fn birthtime_ts(path: &Path) -> TimeSpec {
 #[derive(Debug)]
 #[must_use]
 /// Builder to create a time metadata assertion,
-/// which compares metadata of one file `before` to many files `after`.
-struct TimeAssertion<'a, F> {
-    before_path: &'a Path,
-    after_paths: Vec<&'a Path>,
-    atime: bool,
-    ctime: bool,
-    mtime: bool,
+/// which compares metadata between pairs of paths.
+struct TimeAssertion<'a> {
+    compared_paths: Vec<(&'a Path, &'a Path, TimestampField)>,
     equal: bool,
-    no_follow_symlink: bool,
-    fun: F,
 }
 
-impl<'a, F> TimeAssertion<'a, F>
-where
-    F: FnOnce(),
-{
-    /// Return a new builder with the provided path being the `before` compared path
-    /// and added to the `after` compared paths.
-    /// Comparision will be an equality check if `equal` is true, or an ordering one if it is false.
-    pub fn new<P: AsRef<Path>>(path: &'a P, equal: bool, fun: F) -> Self {
+impl<'a> TimeAssertion<'a> {
+    /// Return a new builder.
+    /// Comparison will be an equality check if `equal` is true, or an ordering one if it is false.
+    pub fn new(equal: bool) -> Self {
         Self {
-            before_path: path.as_ref(),
-            after_paths: vec![path.as_ref()],
-            atime: false,
-            ctime: false,
-            mtime: false,
-            no_follow_symlink: false,
+            compared_paths: vec![],
             equal,
-            fun,
         }
     }
 
-    /// Return a new builder with the provided path being the `before` compared path.
-    /// Comparision will be an equality check if `equal` is true, or an ordering one if it is false.
-    pub fn new_with_paths<P: AsRef<Path>>(before_path: &'a P, equal: bool, fun: F) -> Self {
-        Self {
-            before_path: before_path.as_ref(),
-            after_paths: vec![],
-            atime: false,
-            ctime: false,
-            mtime: false,
-            no_follow_symlink: false,
-            equal,
-            fun,
-        }
+    /// Add a path that should compare with itself.
+    pub fn path(self, path: &'a Path, fields: TimestampField) -> Self {
+        self.paths(path, path, fields)
     }
 
-    /// Add a path to the `after` compared paths.
-    pub fn add_after<P: AsRef<Path>>(mut self, path: &'a P) -> Self {
-        self.after_paths.push(path.as_ref());
-        self
-    }
-
-    /// Add the `st_atime` field to those being compared.
-    pub fn atime(mut self) -> Self {
-        self.atime = true;
-        self
-    }
-
-    /// Add the `st_ctime` field to those being compared.
-    pub fn ctime(mut self) -> Self {
-        self.ctime = true;
-        self
-    }
-
-    /// Add the `st_mtime` field to those being compared.
-    pub fn mtime(mut self) -> Self {
-        self.mtime = true;
-        self
-    }
-
-    /// Get metadata without following symlinks.
-    pub fn no_follow_symlink(mut self) -> Self {
-        self.no_follow_symlink = true;
+    /// Add paths that should compare.
+    pub fn paths(
+        mut self,
+        path_before: &'a Path,
+        path_after: &'a Path,
+        fields: TimestampField,
+    ) -> Self {
+        self.compared_paths
+            .push((path_before.as_ref(), path_after.as_ref(), fields));
         self
     }
 
     /// Build the assertion and asserts that `before` metadata
-    /// is either equal or before the `after` metadata.
-    pub fn assert(self, ctx: &TestContext) {
-        if !(self.atime || self.ctime || self.mtime) || self.after_paths.is_empty() {
-            unimplemented!()
-        }
-
-        let get_metadata = if self.no_follow_symlink {
+    /// is either equal to or different from the `after` metadata.
+    pub fn execute<F>(self, ctx: &TestContext, no_follow_symlink: bool, f: F)
+    where
+        F: FnOnce(),
+    {
+        let get_metadata = if no_follow_symlink {
             symlink_metadata
         } else {
             metadata
         };
 
-        let meta_before = get_metadata(self.before_path)
-            .unwrap()
-            .time_meta(self.atime, self.ctime, self.mtime);
-
-        ctx.nap();
-
-        (self.fun)();
-
-        let metas_after: Vec<_> = self
-            .after_paths
-            .into_iter()
-            .map(|p| {
-                get_metadata(p)
-                    .unwrap()
-                    .time_meta(self.atime, self.ctime, self.mtime)
+        let metas_before: Vec<_> = self
+            .compared_paths
+            .iter()
+            .map(|&(path, _, fields)| {
+                let meta = get_metadata(path).unwrap();
+                (
+                    (fields & TimestampField::ATIME != 0).then(|| meta.atime_ts()),
+                    (fields & TimestampField::CTIME != 0).then(|| meta.ctime_ts()),
+                    (fields & TimestampField::MTIME != 0).then(|| meta.mtime_ts()),
+                )
             })
             .collect();
 
-        for meta_after in metas_after {
-            if self.equal {
-                assert_eq!(meta_before, meta_after);
-            } else {
-                assert!(meta_after > meta_before);
-            }
-        }
+        ctx.nap();
+
+        f();
+
+        let metas_after: Vec<_> = self
+            .compared_paths
+            .into_iter()
+            .map(|(_, path, fields)| {
+                let meta = get_metadata(path).unwrap();
+                (
+                    (fields & TimestampField::ATIME != 0).then(|| meta.atime_ts()),
+                    (fields & TimestampField::CTIME != 0).then(|| meta.ctime_ts()),
+                    (fields & TimestampField::MTIME != 0).then(|| meta.mtime_ts()),
+                )
+            })
+            .collect();
+
+        let cmp = if self.equal {
+            std::cmp::PartialEq::eq
+        } else {
+            std::cmp::PartialEq::ne
+        };
+
+        assert!(metas_before
+            .iter()
+            .zip(metas_after.iter())
+            .all(|(mb, ma)| cmp(mb, ma)));
     }
+}
+
+/// Alias for `TimeAssertion::new(false)`.
+fn assert_times_changed<'a>() -> TimeAssertion<'a> {
+    TimeAssertion::new(false)
+}
+
+/// Alias for `TimeAssertion::new(true)`.
+fn assert_times_unchanged<'a>() -> TimeAssertion<'a> {
+    TimeAssertion::new(true)
 }
 
 /// Assert that a certain operation changes the ctime of a file.
@@ -243,7 +241,9 @@ fn assert_ctime_changed<F>(ctx: &TestContext, path: &Path, f: F)
 where
     F: FnOnce(),
 {
-    TimeAssertion::new(&path, false, f).ctime().assert(ctx)
+    assert_times_changed()
+        .path(&path, TimestampField::CTIME)
+        .execute(ctx, false, f)
 }
 
 /// Assert that a certain operation changes the mtime of a file.
@@ -251,7 +251,9 @@ fn assert_mtime_changed<F>(ctx: &TestContext, path: &Path, f: F)
 where
     F: FnOnce(),
 {
-    TimeAssertion::new(&path, false, f).mtime().assert(ctx)
+    assert_times_changed()
+        .path(&path, TimestampField::MTIME)
+        .execute(ctx, false, f)
 }
 
 /// Assert that a certain operation does not change the ctime of a file.
@@ -259,7 +261,9 @@ fn assert_ctime_unchanged<F>(ctx: &TestContext, path: &Path, f: F)
 where
     F: FnOnce(),
 {
-    TimeAssertion::new(&path, true, f).ctime().assert(ctx)
+    assert_times_unchanged()
+        .path(&path, TimestampField::CTIME)
+        .execute(ctx, false, f)
 }
 
 /// Assert that a certain operation does not change the ctime of a file without following symlinks.
@@ -267,10 +271,9 @@ fn assert_symlink_ctime_unchanged<F>(ctx: &TestContext, path: &Path, f: F)
 where
     F: FnOnce(),
 {
-    TimeAssertion::new(&path, true, f)
-        .ctime()
-        .no_follow_symlink()
-        .assert(ctx)
+    assert_times_unchanged()
+        .path(&path, TimestampField::CTIME)
+        .execute(ctx, true, f)
 }
 
 /// Assert that a certain operation does not change the mtime of a file.
@@ -278,5 +281,7 @@ fn assert_mtime_unchanged<F>(ctx: &TestContext, path: &Path, f: F)
 where
     F: FnOnce(),
 {
-    TimeAssertion::new(&path, true, f).mtime().assert(ctx)
+    assert_times_unchanged()
+        .path(&path, TimestampField::MTIME)
+        .execute(ctx, false, f)
 }

--- a/rust/src/tests/mod.rs
+++ b/rust/src/tests/mod.rs
@@ -34,11 +34,9 @@ pub mod utimensat;
 #[derive(Debug, Clone, Copy)]
 struct TimestampField(u32);
 
-impl TimestampField {
-    pub const ATIME: TimestampField = TimestampField(0b001);
-    pub const CTIME: TimestampField = TimestampField(0b010);
-    pub const MTIME: TimestampField = TimestampField(0b100);
-}
+const ATIME: TimestampField = TimestampField(0b001);
+const CTIME: TimestampField = TimestampField(0b010);
+const MTIME: TimestampField = TimestampField(0b100);
 
 impl PartialEq<u32> for TimestampField {
     fn eq(&self, other: &u32) -> bool {
@@ -189,9 +187,9 @@ impl<'a> TimeAssertion<'a> {
             .map(|&(path, _, fields)| {
                 let meta = get_metadata(path).unwrap();
                 (
-                    (fields & TimestampField::ATIME != 0).then(|| meta.atime_ts()),
-                    (fields & TimestampField::CTIME != 0).then(|| meta.ctime_ts()),
-                    (fields & TimestampField::MTIME != 0).then(|| meta.mtime_ts()),
+                    (fields & ATIME != 0).then(|| meta.atime_ts()),
+                    (fields & CTIME != 0).then(|| meta.ctime_ts()),
+                    (fields & MTIME != 0).then(|| meta.mtime_ts()),
                 )
             })
             .collect();
@@ -206,9 +204,9 @@ impl<'a> TimeAssertion<'a> {
             .map(|(_, path, fields)| {
                 let meta = get_metadata(path).unwrap();
                 (
-                    (fields & TimestampField::ATIME != 0).then(|| meta.atime_ts()),
-                    (fields & TimestampField::CTIME != 0).then(|| meta.ctime_ts()),
-                    (fields & TimestampField::MTIME != 0).then(|| meta.mtime_ts()),
+                    (fields & ATIME != 0).then(|| meta.atime_ts()),
+                    (fields & CTIME != 0).then(|| meta.ctime_ts()),
+                    (fields & MTIME != 0).then(|| meta.mtime_ts()),
                 )
             })
             .collect();
@@ -242,7 +240,7 @@ where
     F: FnOnce(),
 {
     assert_times_changed()
-        .path(&path, TimestampField::CTIME)
+        .path(&path, CTIME)
         .execute(ctx, false, f)
 }
 
@@ -252,7 +250,7 @@ where
     F: FnOnce(),
 {
     assert_times_changed()
-        .path(&path, TimestampField::MTIME)
+        .path(&path, MTIME)
         .execute(ctx, false, f)
 }
 
@@ -262,7 +260,7 @@ where
     F: FnOnce(),
 {
     assert_times_unchanged()
-        .path(&path, TimestampField::CTIME)
+        .path(&path, CTIME)
         .execute(ctx, false, f)
 }
 
@@ -272,7 +270,7 @@ where
     F: FnOnce(),
 {
     assert_times_unchanged()
-        .path(&path, TimestampField::CTIME)
+        .path(&path, CTIME)
         .execute(ctx, true, f)
 }
 
@@ -282,6 +280,6 @@ where
     F: FnOnce(),
 {
     assert_times_unchanged()
-        .path(&path, TimestampField::MTIME)
+        .path(&path, MTIME)
         .execute(ctx, false, f)
 }


### PR DESCRIPTION
Add mk{dir,fifo,nod}/00.t tests.
Also add a time assertion API, which allows more customization on fields being compared and how many files can be compared.

On a side-note, I'm not sure if it's normal that there isn't a test to check that the parent directory time metadata hasn't changed after a failed syscall.