### PR TITLE
Add EEXIST tests

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -190,6 +190,7 @@ name = "pjdfs_tests"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "cfg-if",
  "figment",
  "gumdrop",
  "inventory",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+cfg-if = "1.0"
 libc = "0.2.126"
 tempfile = "3.3.0"
 rand = { version = "0.8.5", features = ["min_const_gen"] }

--- a/rust/src/tests/link.rs
+++ b/rust/src/tests/link.rs
@@ -146,3 +146,10 @@ fn unchanged_ctime_fails(ctx: &mut SerializedTestContext, ft: FileType) {
         });
     })
 }
+
+// link/10.t
+crate::eexist_test_case! {link, |ctx: &mut TestContext, path| {
+        let file = ctx.create(FileType::Regular).unwrap();
+        link(&*file, path)
+    }
+}

--- a/rust/src/tests/mkdir.rs
+++ b/rust/src/tests/mkdir.rs
@@ -44,3 +44,8 @@ fn changed_time_fields_success(ctx: &mut TestContext) {
             mkdir(&path, Mode::from_bits_truncate(0o755)).unwrap();
         });
 }
+
+// mkdir/10.t
+crate::eexist_test_case! {mkdir, |_ctx, path|
+    mkdir(path, Mode::from_bits_truncate(0o755))
+}

--- a/rust/src/tests/mkfifo.rs
+++ b/rust/src/tests/mkfifo.rs
@@ -44,3 +44,8 @@ fn changed_time_fields_success(ctx: &mut TestContext) {
             mkfifo(&path, Mode::from_bits_truncate(0o600)).unwrap();
         });
 }
+
+// mkfifo/09.t
+crate::eexist_test_case! {mkfifo, |_ctx, path|
+    mkfifo(path, Mode::from_bits_truncate(0o600))
+}

--- a/rust/src/tests/mknod.rs
+++ b/rust/src/tests/mknod.rs
@@ -49,3 +49,8 @@ fn changed_time_fields_success(ctx: &mut TestContext) {
             mknod_wrapper(&path, Mode::from_bits_truncate(0o644)).unwrap();
         });
 }
+
+// mknod/08.t
+crate::eexist_test_case! {mknod, |_ctx, path|
+    mknod(path, SFlag::S_IFIFO, Mode::from_bits_truncate(0o600), 0)
+}

--- a/rust/src/tests/mksyscalls.rs
+++ b/rust/src/tests/mksyscalls.rs
@@ -16,6 +16,25 @@ use crate::{
     utils::{chmod, ALLPERMS},
 };
 
+/// Generates a test case that tries to create a file, expecting it to fail with
+/// EEXIST.
+#[macro_export]
+macro_rules! eexist_test_case {
+    ($syscall:ident, $f:expr) => {
+        $crate::test_case! {
+            /// Syscall returns EEXIST if the file already exists
+            eexist
+        }
+        fn eexist(ctx: &mut crate::test::TestContext) {
+            let path = ctx.gen_path();
+
+            let mode = nix::sys::stat::Mode::from_bits_truncate(0o755);
+            ::nix::unistd::mkdir(&path, mode).unwrap();
+            assert_eq!($f(ctx, &path), Err(nix::errno::Errno::EEXIST));
+        }
+    };
+}
+
 /// Assert that the created entry gets its permission bits from the mode
 /// provided to the function negated by the process's file creation mask
 /// (umask), and its file type is equal to the expected one.

--- a/rust/src/tests/mod.rs
+++ b/rust/src/tests/mod.rs
@@ -23,6 +23,7 @@ pub mod mkdir;
 pub mod mkfifo;
 pub mod mknod;
 mod mksyscalls;
+pub mod open;
 pub mod posix_fallocate;
 pub mod rename;
 pub mod rmdir;

--- a/rust/src/tests/open.rs
+++ b/rust/src/tests/open.rs
@@ -1,0 +1,9 @@
+use nix::{
+    fcntl::{open, OFlag},
+    sys::stat::Mode,
+};
+
+// open/22.t
+crate::eexist_test_case! {open, |_ctx, path|
+    open(path, OFlag::O_CREAT | OFlag::O_EXCL, Mode::from_bits_truncate(0o644))
+}

--- a/rust/src/tests/rmdir.rs
+++ b/rust/src/tests/rmdir.rs
@@ -1,8 +1,13 @@
 use std::fs::metadata;
 
+use cfg_if::cfg_if;
 use nix::{errno::Errno, sys::stat::lstat};
 
-use crate::{runner::context::TestContext, tests::assert_mtime_changed, utils::rmdir};
+use crate::{
+    runner::context::{FileBuilder, FileType, TestContext},
+    tests::assert_mtime_changed,
+    utils::rmdir,
+};
 
 use super::assert_ctime_changed;
 
@@ -28,4 +33,48 @@ fn changed_time_parent_success(ctx: &mut TestContext) {
             assert!(rmdir(&dir).is_ok());
         });
     });
+}
+
+crate::test_case! {
+    /// rmdir returns EEXIST or ENOTEMPTY if the named directory contains files
+    /// other than '.' and '..' in it
+    enotempty => [Regular, Dir, Fifo, Block, Char, Socket, Symlink(None)]
+    // rmdir/06.t
+}
+fn enotempty(ctx: &mut TestContext, ft: FileType) {
+    let dir0 = ctx.new_file(FileType::Dir).mode(0o755).create().unwrap();
+    let _file0 = FileBuilder::new(ft, &dir0).create().unwrap();
+    let e = rmdir(&dir0).unwrap_err();
+    assert!(e == Errno::EEXIST || e == Errno::ENOTEMPTY);
+}
+
+crate::test_case! {
+    /// rmdir returns EINVAL if the last component of the path is '.'
+    einval_dot
+    //rmdir/12.t
+}
+fn einval_dot(ctx: &mut TestContext) {
+    let dir0 = ctx.new_file(FileType::Dir).mode(0o755).create().unwrap();
+    let dir1 = FileBuilder::new(FileType::Dir, &dir0).create().unwrap();
+    assert_eq!(Err(Errno::EINVAL), rmdir(&dir1.join(".")));
+}
+
+crate::test_case! {
+    /// rmdir returns EEXIST or ENOTEMPTY if the last component of the path is
+    /// '..'
+    enotempty_dotdot
+    //rmdir/12.t
+}
+fn enotempty_dotdot(ctx: &mut TestContext) {
+    let dir0 = ctx.new_file(FileType::Dir).mode(0o755).create().unwrap();
+    let dir1 = FileBuilder::new(FileType::Dir, &dir0).create().unwrap();
+    let e = rmdir(&dir1.join("..")).unwrap_err();
+    cfg_if! {
+        if #[cfg(target_os = "freebsd")] {
+            // XXX FreeBSD's behavior here is not POSIX compliant
+            assert_eq!(e, Errno::EINVAL);
+        } else {
+            assert!(e == Errno::EEXIST || e == Errno::ENOTEMPTY, "{:?}", e);
+        }
+    }
 }

--- a/rust/src/tests/symlink.rs
+++ b/rust/src/tests/symlink.rs
@@ -1,6 +1,7 @@
 use std::{
     fs::{metadata, remove_dir, remove_file, symlink_metadata},
     os::unix::{fs::symlink, prelude::FileTypeExt},
+    path::Path,
 };
 
 use nix::{errno::Errno, sys::stat::stat};
@@ -72,4 +73,9 @@ fn changed_parent_time_success(ctx: &mut TestContext) {
             ctx.create(FileType::Symlink(None)).unwrap();
         })
     });
+}
+
+// symlink/8.t
+crate::eexist_test_case! {symlink, |_ctx, path|
+    crate::utils::symlink(Path::new("nonexistent"), path)
 }


### PR DESCRIPTION
Add tests that all create-type syscalls will fail with EEXIST if the
target already exists.