### PR TITLE
feat(tests): replace file flag conditions by guards

### DIFF
--- a/rust/src/features.rs
+++ b/rust/src/features.rs
@@ -1,0 +1,36 @@
+use serde::{Deserialize, Serialize};
+
+/// Features which are not available for every file system.
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    strum::Display,
+    strum::EnumIter,
+    strum::EnumMessage,
+    Serialize,
+    Deserialize,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum FileSystemFeature {
+    /// The chflags syscall is available
+    Chflags,
+    /// NFSv4 style Access Control Lists
+    Nfsv4Acls,
+    /// The posix_fallocate syscall is available
+    PosixFallocate,
+    /// rename changes st_ctime on success
+    /// POSIX does not require a file system to update a file's ctime when it gets renamed, but some file systems choose to do it anyway.
+    RenameCtime,
+    /// struct stat contains an st_birthtime field
+    StatStBirthtime,
+    /// The SF_SNAPSHOT flag can be set with chflags
+    ChflagsSfSnapshot,
+    /// The UTIME_NOW constant is available
+    UtimeNow,
+    /// The utimensat syscall is available
+    Utimensat,
+}

--- a/rust/src/macros.rs
+++ b/rust/src/macros.rs
@@ -19,19 +19,19 @@ macro_rules! test_case {
 
 
 
-    (@serialized $f:ident, $features:expr, $flags:expr, $desc:expr, $require_root:expr ) => {
+    (@serialized $f:ident, $features:expr, $guards:expr, $desc:expr, $require_root:expr ) => {
         ::inventory::submit! {
             $crate::test::TestCase {
                 name: concat!(module_path!(), "::", stringify!($f)),
                 description: $desc,
                 required_features: $features,
-                required_file_flags: $flags,
+                guards: $guards,
                 require_root: $require_root,
                 fun: $crate::test::TestFn::Serialized($f),
             }
         }
     };
-    (@serialized $f:ident, $features:expr, $flags:expr, $desc:expr, $require_root:expr => [$( $file_type:tt $( ($ft_args: tt) )? ),+ $(,)*]) => {
+    (@serialized $f:ident, $features:expr, $guards:expr, $desc:expr, $require_root:expr => [$( $file_type:tt $( ($ft_args: tt) )? ),+ $(,)*]) => {
         $(
             paste::paste! {
                 ::inventory::submit! {
@@ -39,7 +39,7 @@ macro_rules! test_case {
                         name: concat!(module_path!(), "::", stringify!($f), "::", stringify!([<$file_type:lower>])),
                         description: $desc,
                         required_features: $features,
-                        required_file_flags: $flags,
+                        guards: $guards,
                         require_root: $require_root || $crate::runner::context::FileType::$file_type $( ($ft_args) )?.privileged(),
                         fun: $crate::test::TestFn::Serialized(|ctx| $f(ctx, $crate::runner::context::FileType::$file_type $( ($ft_args) )?)),
                     }
@@ -48,19 +48,19 @@ macro_rules! test_case {
         )+
     };
 
-    (@ $f:ident, $features:expr, $flags:expr, $require_root:expr, $desc:expr ) => {
+    (@ $f:ident, $features:expr, $guards:expr, $require_root:expr, $desc:expr ) => {
         ::inventory::submit! {
             $crate::test::TestCase {
                 name: concat!(module_path!(), "::", stringify!($f)),
                 description: $desc,
                 required_features: $features,
-                required_file_flags: $flags,
+                guards: $guards,
                 require_root: $require_root,
                 fun: $crate::test::TestFn::NonSerialized($f),
             }
         }
     };
-    (@ $f:ident, $features:expr, $flags:expr, $require_root:expr, $desc:expr => [$( $file_type:tt $( ($ft_args: tt) )? ),+ $(,)*]) => {
+    (@ $f:ident, $features:expr, $guards:expr, $require_root:expr, $desc:expr => [$( $file_type:tt $( ($ft_args: tt) )? ),+ $(,)*]) => {
         $(
             paste::paste! {
                 ::inventory::submit! {
@@ -68,7 +68,7 @@ macro_rules! test_case {
                         name: concat!(module_path!(), "::", stringify!($f), "::", stringify!([<$file_type:lower>])),
                         description: $desc,
                         required_features: $features,
-                        required_file_flags: $flags,
+                        guards: $guards,
                         require_root: $require_root || $crate::runner::context::FileType::$file_type $( ($ft_args) )?.privileged(),
                         fun: $crate::test::TestFn::NonSerialized(|ctx| $f(ctx, $crate::runner::context::FileType::$file_type $( ($ft_args) )?)),
                     }
@@ -81,17 +81,9 @@ macro_rules! test_case {
 #[cfg(test)]
 mod t {
     use crate::runner::context::FileType;
-    #[cfg(any(
-        target_os = "openbsd",
-        target_os = "netbsd",
-        target_os = "freebsd",
-        target_os = "dragonfly",
-        target_os = "macos",
-        target_os = "ios",
-    ))]
-    use crate::test::FileFlags;
     use crate::test::FileSystemFeature;
     use crate::{SerializedTestContext, TestCase, TestContext, TestFn};
+    use std::path::Path;
 
     crate::test_case! {
         /// description
@@ -106,8 +98,8 @@ mod t {
         assert_eq!(" description", tc.description);
         assert!(!tc.require_root);
         assert!(tc.required_features.is_empty());
-        assert!(tc.required_file_flags.is_empty());
         assert!(matches!(tc.fun, TestFn::NonSerialized(f) if f as usize == basic as usize));
+        assert!(tc.guards.is_empty());
     }
 
     crate::test_case! {
@@ -129,52 +121,34 @@ mod t {
                 FileSystemFeature::PosixFallocate
             ]
         );
-        assert!(tc.required_file_flags.is_empty());
         assert!(matches!(tc.fun, TestFn::NonSerialized(f) if f as usize == features as usize));
+        assert!(tc.guards.is_empty());
     }
 
-    #[cfg(any(
-        target_os = "openbsd",
-        target_os = "netbsd",
-        target_os = "freebsd",
-        target_os = "dragonfly",
-        target_os = "macos",
-        target_os = "ios",
-    ))]
+    fn guard_example(_: &crate::config::Config, _: &Path) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     crate::test_case! {
         /// description
-        flags, FileSystemFeature::Chflags; FileFlags::SF_IMMUTABLE, FileFlags::UF_IMMUTABLE
+        guard; guard_example
     }
-    #[cfg(any(
-        target_os = "openbsd",
-        target_os = "netbsd",
-        target_os = "freebsd",
-        target_os = "dragonfly",
-        target_os = "macos",
-        target_os = "ios",
-    ))]
-    fn flags(_: &mut TestContext) {}
-    #[cfg(any(
-        target_os = "openbsd",
-        target_os = "netbsd",
-        target_os = "freebsd",
-        target_os = "dragonfly",
-        target_os = "macos",
-        target_os = "ios",
-    ))]
+    fn guard(_: &mut TestContext) {}
     #[test]
-    fn flags_test() {
+    fn guard_test() {
         let tc = inventory::iter::<TestCase>()
-            .find(|tc| tc.name == "pjdfstest::macros::t::flags")
+            .find(|tc| tc.name == "pjdfstest::macros::t::guard")
             .unwrap();
         assert_eq!(" description", tc.description);
         assert!(!tc.require_root);
-        assert_eq!(tc.required_features, &[FileSystemFeature::Chflags]);
         assert_eq!(
-            tc.required_file_flags,
-            &[FileFlags::SF_IMMUTABLE, FileFlags::UF_IMMUTABLE]
+            tc.guards
+                .into_iter()
+                .map(|&g| g as usize)
+                .collect::<Vec<_>>(),
+            vec![guard_example as usize]
         );
-        assert!(matches!(tc.fun, TestFn::NonSerialized(f) if f as usize == flags as usize));
+        assert!(matches!(tc.fun, TestFn::NonSerialized(f) if f as usize == guard as usize));
     }
 
     crate::test_case! {
@@ -190,8 +164,8 @@ mod t {
         assert_eq!(" description", tc.description);
         assert!(tc.require_root);
         assert!(tc.required_features.is_empty());
-        assert!(tc.required_file_flags.is_empty());
         assert!(matches!(tc.fun, TestFn::NonSerialized(f) if f as usize == root as usize));
+        assert!(tc.guards.is_empty());
     }
 
     crate::test_case! {
@@ -207,7 +181,7 @@ mod t {
         assert_eq!(" description", tc.description);
         assert!(!tc.require_root);
         assert!(tc.required_features.is_empty());
-        assert!(tc.required_file_flags.is_empty());
+        assert!(tc.guards.is_empty());
         // Can't check fun because it's a closure
 
         let tc = inventory::iter::<TestCase>()
@@ -216,7 +190,7 @@ mod t {
         assert_eq!(" description", tc.description);
         assert!(!tc.require_root);
         assert!(tc.required_features.is_empty());
-        assert!(tc.required_file_flags.is_empty());
+        assert!(tc.guards.is_empty());
         // Can't check fun because it's a closure
     }
 
@@ -233,7 +207,7 @@ mod t {
         assert_eq!(" description", tc.description);
         assert!(!tc.require_root);
         assert!(tc.required_features.is_empty());
-        assert!(tc.required_file_flags.is_empty());
         assert!(matches!(tc.fun, TestFn::Serialized(f) if f as usize == serialized as usize));
+        assert!(tc.guards.is_empty());
     }
 }

--- a/rust/src/test.rs
+++ b/rust/src/test.rs
@@ -1,9 +1,11 @@
 use std::fmt::Debug;
+use std::path::Path;
 
-use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-pub use crate::flags::FileFlags;
+use crate::config::Config;
+pub use crate::features::*;
+pub use crate::flags::*;
 pub use crate::runner::context::{SerializedTestContext, TestContext};
 
 /// Error returned by a test function.
@@ -12,6 +14,9 @@ pub enum TestError {
     #[error("error while calling syscall: {0}")]
     Nix(#[from] nix::Error),
 }
+
+/// Function which indicates if the test should be skipped by returning an error.
+pub type Guard = fn(&Config, &Path) -> Result<(), anyhow::Error>;
 
 pub enum TestFn {
     Serialized(fn(&mut SerializedTestContext)),
@@ -25,40 +30,7 @@ pub struct TestCase {
     pub require_root: bool,
     pub fun: TestFn,
     pub required_features: &'static [FileSystemFeature],
-    pub required_file_flags: &'static [FileFlags],
+    pub guards: &'static [Guard],
 }
 
 inventory::collect!(TestCase);
-
-/// Features which are not available for every file system.
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    Hash,
-    strum::Display,
-    strum::EnumIter,
-    strum::EnumMessage,
-    Serialize,
-    Deserialize,
-)]
-#[serde(rename_all = "snake_case")]
-#[strum(serialize_all = "snake_case")]
-pub enum FileSystemFeature {
-    /// The chflags syscall is available
-    Chflags,
-    /// NFSv4 style Access Control Lists
-    Nfsv4Acls,
-    /// The posix_fallocate syscall is available
-    PosixFallocate,
-    /// rename changes st_ctime on success
-    /// POSIX does not require a file system to update a file's ctime when it gets renamed, but some file systems choose to do it anyway.
-    RenameCtime,
-    /// struct stat contains an st_birthtime field
-    StatStBirthtime,
-    /// The UTIME_NOW constant is available
-    UtimeNow,
-    /// The utimensat syscall is available
-    Utimensat,
-}

--- a/rust/src/tests/chmod/errno.rs
+++ b/rust/src/tests/chmod/errno.rs
@@ -5,9 +5,6 @@ use nix::{
 
 use crate::{runner::context::FileType, test::TestContext, utils::chmod};
 
-#[cfg(target_os = "freebsd")]
-use crate::test::{FileFlags, FileSystemFeature};
-
 crate::test_case! {
     /// Returns ENOTDIR if a component of the path prefix is not a directory
     enotdir => [Regular, Fifo, Block, Char, Socket]
@@ -36,12 +33,4 @@ fn enametoolong(ctx: &mut TestContext) {
     let res = chmod(&too_long_path, Mode::from_bits_truncate(0o0620));
     assert!(res.is_err());
     assert_eq!(res.unwrap_err(), Errno::ENAMETOOLONG);
-}
-
-#[cfg(target_os = "freebsd")]
-crate::test_case! {eperm_immutable_flag, FileSystemFeature::Chflags; FileFlags::SF_IMMUTABLE}
-#[cfg(target_os = "freebsd")]
-fn eperm_immutable_flag(ctx: &mut TestContext) {
-    let _path = ctx.create(FileType::Regular).unwrap();
-    //TODO: Complete
 }

--- a/rust/src/tests/mod.rs
+++ b/rust/src/tests/mod.rs
@@ -295,3 +295,153 @@ where
         .path(path, MTIME)
         .execute(ctx, false, f)
 }
+
+/// Guard to conditionally skip tests on platforms which do not support
+/// the required file flags.
+macro_rules! support_file_flags {
+    ($($flags: ident),*) => {
+        |config, _| {
+            let flags = &[ $(crate::flags::FileFlags::$flags),* ].iter().copied().collect();
+            if config.features.file_flags.is_superset(&flags) {
+                Ok(())
+            } else {
+                let unsupported_flags = flags.difference(&config.features.file_flags)
+                    .map(std::string::ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", ");
+
+                anyhow::bail!("file flags {unsupported_flags} aren't supported")
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod t {
+    use crate::{config::Config, test::TestCase};
+
+    use super::*;
+
+    crate::test_case! {support_flags_empty; support_file_flags!()}
+    fn support_flags_empty(_: &mut TestContext) {}
+    #[test]
+    fn support_flags_test_empty() {
+        let config = Config::default();
+        let tc: &TestCase = inventory::iter::<TestCase>()
+            .find(|tc| tc.name == "pjdfstest::tests::t::support_flags_empty")
+            .unwrap();
+        assert_eq!(tc.guards.len(), 1);
+
+        let guard = &tc.guards[0];
+        assert!(guard(&config, Path::new("test")).is_ok());
+    }
+
+    #[cfg(any(
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "watchos",
+    ))]
+    crate::test_case! {support_flags_unique; support_file_flags!(SF_APPEND)}
+    #[cfg(any(
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "watchos",
+    ))]
+    fn support_flags_unique(_: &mut TestContext) {}
+    #[cfg(any(
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "watchos",
+    ))]
+    #[test]
+    fn support_flags_test_unique() {
+        use std::collections::HashSet;
+
+        use crate::flags::FileFlags;
+
+        let mut config = Config::default();
+        let tc: &TestCase = inventory::iter::<TestCase>()
+            .find(|tc| tc.name == "pjdfstest::tests::t::support_flags_unique")
+            .unwrap();
+        assert_eq!(tc.guards.len(), 1);
+
+        let guard = &tc.guards[0];
+        assert!(guard(&config, Path::new("test")).is_err());
+
+        config.features.file_flags = HashSet::from([FileFlags::SF_APPEND]);
+        assert!(guard(&config, Path::new("test")).is_ok());
+
+        config.features.file_flags = HashSet::from([FileFlags::SF_APPEND, FileFlags::UF_APPEND]);
+        assert!(guard(&config, Path::new("test")).is_ok());
+    }
+
+    #[cfg(any(
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "watchos",
+    ))]
+    crate::test_case! {support_flags_not_empty; support_file_flags!(SF_APPEND, UF_APPEND)}
+    #[cfg(any(
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "watchos",
+    ))]
+    fn support_flags_not_empty(_: &mut TestContext) {}
+    #[cfg(any(
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "watchos",
+    ))]
+    #[test]
+    fn support_flags_test_not_empty() {
+        use std::collections::HashSet;
+
+        use crate::flags::FileFlags;
+
+        let mut config = Config::default();
+        let tc: &TestCase = inventory::iter::<TestCase>()
+            .find(|tc| tc.name == "pjdfstest::tests::t::support_flags_not_empty")
+            .unwrap();
+        assert_eq!(tc.guards.len(), 1);
+
+        let guard = &tc.guards[0];
+        assert!(guard(&config, Path::new("test")).is_err());
+
+        config.features.file_flags = HashSet::from([FileFlags::SF_APPEND]);
+        assert!(guard(&config, Path::new("test")).is_err());
+
+        config.features.file_flags = HashSet::from([FileFlags::SF_APPEND, FileFlags::UF_APPEND]);
+        assert!(guard(&config, Path::new("test")).is_ok());
+
+        config.features.file_flags = HashSet::from([
+            FileFlags::SF_APPEND,
+            FileFlags::UF_APPEND,
+            FileFlags::SF_ARCHIVED,
+        ]);
+        assert!(guard(&config, Path::new("test")).is_ok());
+    }
+}


### PR DESCRIPTION
Guards are functions which test if a requirement is met and returns an error to skip the test if it isn't.
This would allow skipping tests which needs capabilities, for example (https://github.com/musikid/pjdfstest/pull/110#issuecomment-1250312411).