### PR TITLE
feat(tests): add support for EROFS tests

### DIFF
--- a/book/src/configuration-file.md
+++ b/book/src/configuration-file.md
@@ -77,8 +77,12 @@ entries = [
 ```toml
 [settings]
 naptime = 0.001
+allow_erofs = false
 ```
 
 - `naptime` - The duration for a "short" sleep. It should be greater than the
   timestamp granularity of the file system under test. The default value is 1
   second.
+- `allow_erofs` - If set to `true`, the runner will run the EROFS tests,
+  which require to remount the file system on which
+  pjdsfstest is run as read-only.

--- a/book/src/configuration-file.md
+++ b/book/src/configuration-file.md
@@ -77,7 +77,7 @@ entries = [
 ```toml
 [settings]
 naptime = 0.001
-allow_erofs = false
+allow_remount = false
 ```
 
 - `naptime` - The duration for a "short" sleep. It should be greater than the

--- a/book/src/configuration-file.md
+++ b/book/src/configuration-file.md
@@ -83,6 +83,6 @@ allow_remount = false
 - `naptime` - The duration for a "short" sleep. It should be greater than the
   timestamp granularity of the file system under test. The default value is 1
   second.
-- `allow_erofs` - If set to `true`, the runner will run the EROFS tests,
+- `allow_remount` - If set to `true`, the runner will run the EROFS tests,
   which require to remount the file system on which
   pjdsfstest is run as read-only.

--- a/rust/pjdfstest.toml
+++ b/rust/pjdfstest.toml
@@ -19,7 +19,7 @@ posix_fallocate = {}
 naptime = 0.001
 # Allow to run the EROFS tests, which require to remount the file system on which
 # pjdsfstest is run as read-only.
-allow_erofs = false
+allow_remount = false
 
 # This section allows to modify the mecanism for switching users, which is required by some tests.
 # [dummy_auth]

--- a/rust/pjdfstest.toml
+++ b/rust/pjdfstest.toml
@@ -17,6 +17,9 @@ posix_fallocate = {}
 # naptime is the duration of various short sleeps.  It should be greater than
 # the timestamp granularity of the file system under test.
 naptime = 0.001
+# Allow to run the EROFS tests, which require to remount the file system on which
+# pjdsfstest is run as read-only.
+allow_erofs = false
 
 # This section allows to modify the mecanism for switching users, which is required by some tests.
 # [dummy_auth]

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -30,14 +30,14 @@ pub struct FeaturesConfig {
 pub struct SettingsConfig {
     #[serde(default = "default_naptime")]
     pub naptime: f64,
-    pub allow_erofs: bool,
+    pub allow_remount: bool,
 }
 
 impl Default for SettingsConfig {
     fn default() -> Self {
         SettingsConfig {
             naptime: default_naptime(),
-            allow_erofs: false,
+            allow_remount: false,
         }
     }
 }

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -30,12 +30,14 @@ pub struct FeaturesConfig {
 pub struct SettingsConfig {
     #[serde(default = "default_naptime")]
     pub naptime: f64,
+    pub allow_erofs: bool,
 }
 
 impl Default for SettingsConfig {
     fn default() -> Self {
         SettingsConfig {
             naptime: default_naptime(),
+            allow_erofs: false,
         }
     }
 }

--- a/rust/src/context.rs
+++ b/rust/src/context.rs
@@ -14,7 +14,7 @@ use rand::distributions::{Alphanumeric, DistString};
 use std::{
     cell::Cell,
     fs::create_dir_all,
-    ops::Deref,
+    ops::{Deref, DerefMut},
     os::unix::prelude::RawFd,
     panic::{catch_unwind, resume_unwind, AssertUnwindSafe},
     path::{Path, PathBuf},
@@ -88,6 +88,12 @@ impl<'a> Deref for SerializedTestContext<'a> {
 
     fn deref(&self) -> &Self::Target {
         &self.ctx
+    }
+}
+
+impl<'a> DerefMut for SerializedTestContext<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.ctx
     }
 }
 

--- a/rust/src/tests/chflags.rs
+++ b/rust/src/tests/chflags.rs
@@ -22,6 +22,7 @@ use super::{
     errors::enametoolong::{enametoolong_comp_test_case, enametoolong_path_test_case},
     errors::enoent::{enoent_comp_test_case, enoent_named_file_test_case},
     errors::enotdir::enotdir_comp_test_case,
+    errors::erofs::erofs_named_test_case,
 };
 
 //TODO: Split tests with unprivileged tests for user flags
@@ -238,3 +239,6 @@ eloop_comp_test_case!(chflags(~path, FileFlag::empty()));
 
 // chflags/13.t
 efault_path_test_case!(chflags, |ptr| nix::libc::chflags(ptr, 0));
+
+// chflags/12.t
+erofs_named_test_case!(chflags(~path, FileFlag::empty()));

--- a/rust/src/tests/chmod.rs
+++ b/rust/src/tests/chmod.rs
@@ -22,6 +22,7 @@ use super::errors::{
         enoent_comp_test_case, enoent_named_file_test_case, enoent_symlink_named_file_test_case,
     },
     enotdir::enotdir_comp_test_case,
+    erofs::erofs_named_test_case,
 };
 
 const ALLPERMS_STICKY: mode_t = ALLPERMS | Mode::S_ISVTX.bits();
@@ -137,6 +138,9 @@ eloop_comp_test_case!(chmod(~path, Mode::empty()));
 // chmod/06.t
 eloop_final_comp_test_case!(chmod(~path, Mode::empty()));
 
+// chmod/09.t
+erofs_named_test_case!(chmod(~path, Mode::empty()));
+
 // chmod/10.t
 efault_path_test_case!(chmod, |ptr| nix::libc::chmod(ptr, 0));
 
@@ -203,6 +207,9 @@ mod lchmod {
 
     enametoolong_comp_test_case!(lchmod(~path, Mode::empty()));
     enametoolong_path_test_case!(lchmod(~path, Mode::empty()));
+
+    // chmod/09.t
+    erofs_named_test_case!(lchmod(~path, Mode::empty()));
 
     // chmod/10.t
     // TODO: lchmod is missing in libc

--- a/rust/src/tests/chown.rs
+++ b/rust/src/tests/chown.rs
@@ -9,6 +9,7 @@ use super::errors::enoent::{
     enoent_comp_test_case, enoent_named_file_test_case, enoent_symlink_named_file_test_case,
 };
 use super::errors::enotdir::enotdir_comp_test_case;
+use super::errors::erofs::erofs_named_test_case;
 
 fn chown_wrapper(ctx: &mut TestContext, path: &std::path::Path) -> nix::Result<()> {
     let user = ctx.get_new_user();
@@ -38,6 +39,9 @@ enametoolong_comp_test_case!(chown, chown_wrapper);
 // chown/03.t
 enametoolong_path_test_case!(chown, chown_wrapper);
 
+// chown/09.t
+erofs_named_test_case!(chown, chown_wrapper);
+
 // chown/10.t
 efault_path_test_case!(chown, |ptr| nix::libc::chown(ptr, 0, 0));
 
@@ -61,6 +65,9 @@ mod lchown {
 
     enametoolong_comp_test_case!(lchown, lchown_wrapper);
     enametoolong_path_test_case!(lchown, lchown_wrapper);
+
+    // chown/09.t
+    erofs_named_test_case!(lchown, lchown_wrapper);
 
     // chown/10.t
     efault_path_test_case!(lchown, |ptr| nix::libc::lchown(ptr, 0, 0));

--- a/rust/src/tests/errors.rs
+++ b/rust/src/tests/errors.rs
@@ -3,5 +3,6 @@ pub(super) mod eloop;
 pub(super) mod enametoolong;
 pub(super) mod enoent;
 pub(super) mod enotdir;
+pub(super) mod erofs;
 pub(super) mod etxtbsy;
 pub(super) mod exdev;

--- a/rust/src/tests/errors/erofs.rs
+++ b/rust/src/tests/errors/erofs.rs
@@ -14,7 +14,7 @@ enum RemountOptions {
 /// Guard to allow execution of this test only if it's allowed to run.
 pub(crate) fn can_run_erofs(conf: &crate::config::Config, _: &Path) -> anyhow::Result<()> {
     if !conf.settings.allow_remount {
-        anyhow::bail!("EROFS is not enabled in the configuration file")
+        anyhow::bail!("Remounts (allow_remount) are not allowed in the configuration file")
     }
 
     Ok(())

--- a/rust/src/tests/errors/erofs.rs
+++ b/rust/src/tests/errors/erofs.rs
@@ -13,7 +13,7 @@ enum RemountOptions {
 
 /// Guard to allow execution of this test only if it's allowed to run.
 pub(crate) fn can_run_erofs(conf: &crate::config::Config, _: &Path) -> anyhow::Result<()> {
-    if !conf.settings.allow_erofs {
+    if !conf.settings.allow_remount {
         anyhow::bail!("EROFS is not enabled in the configuration file")
     }
 

--- a/rust/src/tests/errors/erofs.rs
+++ b/rust/src/tests/errors/erofs.rs
@@ -1,0 +1,182 @@
+use std::{
+    panic::{catch_unwind, resume_unwind, AssertUnwindSafe},
+    path::Path,
+    process::Command,
+};
+
+use crate::utils::get_mountpoint;
+
+enum RemountOptions {
+    ReadOnly,
+    ReadWrite,
+}
+
+/// Guard to allow execution of this test only if it's allowed to run.
+pub(crate) fn can_run_erofs(conf: &crate::config::Config, _: &Path) -> anyhow::Result<()> {
+    if !conf.settings.allow_erofs {
+        anyhow::bail!("EROFS is not enabled in the configuration file")
+    }
+
+    Ok(())
+}
+
+/// Remount the file system mounted at `mountpoint` with the provided options.
+fn remount<P: AsRef<Path>>(mountpoint: P, options: RemountOptions) -> Result<(), anyhow::Error> {
+    if mountpoint.as_ref().parent().is_none() {
+        anyhow::bail!("Cannot remount root file system")
+    }
+
+    let opt = match options {
+        RemountOptions::ReadOnly => "ro",
+        RemountOptions::ReadWrite => "rw",
+    };
+
+    #[cfg(target_os = "linux")]
+    let opt = format!("remount,{opt}");
+
+    let mut cmd = Command::new("mount");
+
+    #[cfg(any(
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "dragonfly"
+    ))]
+    cmd.arg("-u");
+
+    // XXX: It is possible to do it directly with mount(2) but we use the CLI for now
+    let mount_result = cmd.arg("-o").arg(opt).arg(mountpoint.as_ref()).output()?;
+
+    if !mount_result.status.success() {
+        anyhow::bail!(
+            "Failed to remount: {}",
+            String::from_utf8_lossy(&mount_result.stderr)
+        )
+    }
+
+    Ok(())
+}
+
+/// Execute a function with a read-only file system and restore read/write flags after.
+// TODO: Get the original flags
+pub(crate) fn with_readonly_fs<F, P: AsRef<Path>>(path: P, f: F)
+where
+    F: FnOnce(),
+{
+    let mountpoint = get_mountpoint(path.as_ref()).unwrap();
+
+    remount(mountpoint, RemountOptions::ReadOnly).unwrap();
+
+    let res = catch_unwind(AssertUnwindSafe(f));
+
+    remount(mountpoint, RemountOptions::ReadWrite).unwrap();
+
+    if let Err(e) = res {
+        resume_unwind(e);
+    }
+}
+
+/// Create a test case which asserts that the syscall returns EROFS
+/// if the path resides on a read-only file system.
+/// There are multiple forms for this macro:
+///
+/// - A basic form which takes the syscall, and optionally a `~path` argument
+///   to indicate where the `path` argument should be substituted if the path
+///   is not the only argument taken by the syscall.
+///
+/// ```
+/// // `unlink` accepts only a path as argument.
+/// erofs_new_file_test_case!(unlink);
+/// // `chflags` takes a path and the flags to set as arguments.
+/// // We need to add `~path` where the path argument should normally be taken.
+/// erofs_new_file_test_case!(chflags(~path, FileFlags::empty()));
+/// ```
+///
+/// - A more complex form which takes multiple functions
+///   with the context and the path as arguments for syscalls
+///   requring to compute other arguments.
+///
+/// ```
+/// erofs_new_file_test_case!(chown, |ctx: &mut TestContext, path: &Path| {
+///   let user = ctx.get_new_user();
+///   chown(path, Some(user.uid), None)
+/// })
+/// ```
+macro_rules! erofs_new_file_test_case {
+    ($syscall: ident, $($f: expr),+) => {
+        crate::test_case! {
+            #[doc = concat!(stringify!($syscall),
+                 " returns EROFS if the path for the file to be created resides on a read-only file system")]
+            erofs_new_file, serialized, root; crate::tests::errors::erofs::can_run_erofs
+        }
+        fn erofs_new_file(ctx: &mut crate::context::SerializedTestContext) {
+            use crate::tests::errors::erofs::with_readonly_fs;
+            let path = ctx.base_path().to_owned();
+            let file = ctx.gen_path();
+            with_readonly_fs(path, || {
+                $( assert_eq!($f(ctx, &file), Err(nix::errno::Errno::EROFS)); )+
+            });
+        }
+    };
+
+    ($syscall: ident $( ($( $($before:expr),* ,)? ~path $(, $($after:expr),*)?) )?) => {
+        crate::tests::errors::erofs::erofs_new_file_test_case!($syscall, |_ctx, path: &std::path::Path| {
+                $syscall($( $($($before),* ,)? )? path $( $(, $($after),*)? )?)
+        });
+    };
+}
+
+pub(crate) use erofs_new_file_test_case;
+
+/// Create a test case which asserts that the syscall returns EROFS
+/// if the named file resides on a read-only file system.
+/// There are multiple forms for this macro:
+///
+/// - A basic form which takes the syscall, and optionally a `~path` argument
+///   to indicate where the `path` argument should be substituted if the path
+///   is not the only argument taken by the syscall.
+///
+/// ```
+/// // `unlink` accepts only a path as argument.
+/// erofs_test_case!(unlink);
+/// // `chflags` takes a path and the flags to set as arguments.
+/// // We need to add `~path` where the path argument should normally be taken.
+/// erofs_test_case!(chflags(~path, FileFlags::empty()));
+/// ```
+///
+/// - A more complex form which takes multiple functions
+///   with the context and the path as arguments for syscalls
+///   requring to compute other arguments.
+///
+/// ```
+/// erofs_test_case!(chown, |ctx: &mut TestContext, path: &Path| {
+///   let user = ctx.get_new_user();
+///   chown(path, Some(user.uid), None)
+/// })
+/// ```
+macro_rules! erofs_named_test_case {
+    ($syscall: ident, $($f: expr),+) => {
+        crate::test_case! {
+            #[doc = concat!(stringify!($syscall),
+                 " returns EROFS if the named file resides on a read-only file system")]
+            erofs_named, serialized, root; crate::tests::errors::erofs::can_run_erofs
+        }
+        fn erofs_named(ctx: &mut crate::context::SerializedTestContext) {
+            use crate::tests::errors::erofs::with_readonly_fs;
+            use crate::context::FileType;
+            let path = ctx.base_path().to_owned();
+            let file = ctx.new_file(FileType::Regular).name(path.join("file")).create().unwrap();
+            with_readonly_fs(path, || {
+                $( assert_eq!($f(ctx, &file), Err(nix::errno::Errno::EROFS)); )+
+            });
+        }
+    };
+
+    ($syscall: ident $( ($( $($before:expr),* ,)? ~path $(, $($after:expr),*)?) )?) => {
+        crate::tests::errors::erofs::erofs_named_test_case!($syscall, |_ctx, path: &std::path::Path| {
+                $syscall($( $($($before),* ,)? )? path $( $(, $($after),*)? )?)
+        });
+    };
+}
+
+pub(crate) use erofs_named_test_case;

--- a/rust/src/tests/link.rs
+++ b/rust/src/tests/link.rs
@@ -12,6 +12,7 @@ use super::{
         efault::efault_either_test_case,
         eloop::eloop_either_test_case,
         enametoolong::{enametoolong_either_comp_test_case, enametoolong_either_path_test_case},
+        erofs::erofs_named_test_case,
         exdev::exdev_target_test_case,
     },
     CTIME, MTIME,
@@ -211,6 +212,12 @@ enoent_either_named_file_test_case!(link);
 
 // link/08.t
 eloop_either_test_case!(link);
+
+// link/16.t
+erofs_named_test_case!(link, |ctx: &mut TestContext, file| {
+    let path = ctx.gen_path();
+    link(file, &path)
+});
 
 // link/09.t
 crate::test_case! {

--- a/rust/src/tests/mkdir.rs
+++ b/rust/src/tests/mkdir.rs
@@ -8,6 +8,7 @@ use super::errors::efault::efault_path_test_case;
 use super::errors::eloop::eloop_comp_test_case;
 use super::errors::enametoolong::{enametoolong_comp_test_case, enametoolong_path_test_case};
 use super::errors::enoent::enoent_comp_test_case;
+use super::errors::erofs::erofs_new_file_test_case;
 use super::mksyscalls::{assert_perms_from_mode_and_umask, assert_uid_gid};
 use super::{assert_times_changed, errors::enotdir::enotdir_comp_test_case, ATIME, CTIME, MTIME};
 
@@ -62,6 +63,9 @@ enoent_comp_test_case!(mkdir(~path, Mode::empty()));
 
 // mkdir/07.t
 eloop_comp_test_case!(mkdir(~path, Mode::empty()));
+
+// mkdir/09.t
+erofs_new_file_test_case!(mkdir(~path, Mode::empty()));
 
 // mkdir/12.t
 efault_path_test_case!(mkdir, |ptr| nix::libc::mkdir(ptr, 0o755));

--- a/rust/src/tests/mkfifo.rs
+++ b/rust/src/tests/mkfifo.rs
@@ -9,6 +9,7 @@ use super::errors::eloop::eloop_comp_test_case;
 use super::errors::enametoolong::{enametoolong_comp_test_case, enametoolong_path_test_case};
 use super::errors::enoent::enoent_comp_test_case;
 use super::errors::enotdir::enotdir_comp_test_case;
+use super::errors::erofs::erofs_new_file_test_case;
 use super::mksyscalls::{assert_perms_from_mode_and_umask, assert_uid_gid};
 use super::{assert_times_changed, ATIME, CTIME, MTIME};
 
@@ -64,6 +65,9 @@ enoent_comp_test_case!(mkfifo(~path, Mode::empty()));
 
 // mkfifo/07.t
 eloop_comp_test_case!(mkfifo(~path, Mode::empty()));
+
+// mkfifo/08.t
+erofs_new_file_test_case!(mkfifo(~path, Mode::empty()));
 
 // mkfifo/12.t
 efault_path_test_case!(mkfifo, |ptr| nix::libc::mkfifo(ptr, 0o644));

--- a/rust/src/tests/open.rs
+++ b/rust/src/tests/open.rs
@@ -14,6 +14,7 @@ use super::errors::efault::efault_path_test_case;
 use super::errors::eloop::eloop_comp_test_case;
 use super::errors::enametoolong::{enametoolong_comp_test_case, enametoolong_path_test_case};
 use super::errors::enoent::{enoent_comp_test_case, enoent_named_file_test_case};
+use super::errors::erofs::{erofs_named_test_case, erofs_new_file_test_case};
 use super::errors::etxtbsy::etxtbsy_test_case;
 use super::mksyscalls::{assert_perms_from_mode_and_umask, assert_uid_gid};
 use super::{assert_times_changed, assert_times_unchanged, ATIME, CTIME, MTIME};
@@ -210,6 +211,24 @@ enoent_comp_test_case!(open(~path, OFlag::O_CREAT, Mode::from_bits_truncate(0o64
 // open/04.t
 enoent_named_file_test_case!(open(~path, OFlag::O_RDONLY, Mode::empty()));
 
+fn open_flag_wrapper_ctx(flags: OFlag) -> impl Fn(&mut TestContext, &Path) -> nix::Result<RawFd> {
+    move |_, path| open(path, flags, Mode::empty())
+}
+
+// open/14.t
+erofs_named_test_case!(
+    open,
+    open_flag_wrapper_ctx(OFlag::O_WRONLY),
+    open_flag_wrapper_ctx(OFlag::O_RDWR),
+    open_flag_wrapper_ctx(OFlag::O_RDONLY | OFlag::O_TRUNC)
+);
+
+// open/15.t
+erofs_new_file_test_case!(
+    open,
+    open_flag_wrapper_ctx(OFlag::O_RDONLY | OFlag::O_CREAT,)
+);
+
 // open/12.t
 eloop_comp_test_case!(open(~path, OFlag::empty(), Mode::empty()));
 
@@ -285,16 +304,16 @@ fn locked(ctx: &mut TestContext) {
     assert_ewouldblock(&file, OFlag::O_EXLOCK, OFlag::O_SHLOCK);
 }
 
-fn open_flag_wrapper(flags: OFlag) -> impl Fn(&Path) -> nix::Result<RawFd> {
+fn open_flag_wrapper_path(flags: OFlag) -> impl Fn(&Path) -> nix::Result<RawFd> {
     move |path| open(path, flags, Mode::empty())
 }
 
 // open/20.t
 etxtbsy_test_case!(
     open,
-    open_flag_wrapper(OFlag::O_WRONLY),
-    open_flag_wrapper(OFlag::O_RDWR),
-    open_flag_wrapper(OFlag::O_RDONLY | OFlag::O_TRUNC)
+    open_flag_wrapper_path(OFlag::O_WRONLY),
+    open_flag_wrapper_path(OFlag::O_RDWR),
+    open_flag_wrapper_path(OFlag::O_RDONLY | OFlag::O_TRUNC)
 );
 
 // open/21.t

--- a/rust/src/tests/rename.rs
+++ b/rust/src/tests/rename.rs
@@ -19,7 +19,9 @@ use super::{
         eloop::eloop_either_test_case,
         enametoolong::{enametoolong_either_comp_test_case, enametoolong_either_path_test_case},
         enoent::enoent_either_named_file_test_case,
-        enotdir::enotdir_comp_either_test_case, exdev::exdev_target_test_case,
+        enotdir::enotdir_comp_either_test_case,
+        erofs::erofs_named_test_case,
+        exdev::exdev_target_test_case,
     },
 };
 
@@ -311,6 +313,12 @@ fn eisdir_to_dir_from_not_dir(ctx: &mut TestContext, ft: FileType) {
     let not_dir_file = ctx.create(ft).unwrap();
     assert_eq!(rename(&not_dir_file, &dir), Err(Errno::EISDIR));
 }
+
+// rename/16.t
+erofs_named_test_case!(rename, |ctx: &mut TestContext, file| {
+    let path = ctx.gen_path();
+    rename(file, &path)
+});
 
 // rename/17.t
 efault_either_test_case!(rename, nix::libc::rename);

--- a/rust/src/tests/rmdir.rs
+++ b/rust/src/tests/rmdir.rs
@@ -11,7 +11,7 @@ use crate::{config::Config, context::TestContext, tests::assert_mtime_changed, u
 use super::{
     assert_ctime_changed,
     errors::efault::efault_path_test_case,
-    errors::eloop::eloop_comp_test_case,
+    errors::{eloop::eloop_comp_test_case, erofs::erofs_named_test_case},
     errors::{enametoolong::enametoolong_comp_test_case, enoent::enoent_named_file_test_case},
     errors::{enametoolong::enametoolong_path_test_case, enotdir::enotdir_comp_test_case},
 };
@@ -142,6 +142,9 @@ crate::test_case! {
 fn einval_dot(ctx: &mut TestContext) {
     assert_eq!(rmdir(&ctx.base_path().join(".")), Err(Errno::EINVAL));
 }
+
+// rmdir/14.t
+erofs_named_test_case!(rmdir);
 
 // rmdir/15.t
 efault_path_test_case!(rmdir, nix::libc::rmdir);

--- a/rust/src/tests/symlink.rs
+++ b/rust/src/tests/symlink.rs
@@ -14,6 +14,7 @@ use super::errors::{
     efault::efault_either_test_case,
     enametoolong::{enametoolong_comp_test_case, enametoolong_either_path_test_case},
     enotdir::enotdir_comp_test_case,
+    erofs::erofs_new_file_test_case,
 };
 
 crate::test_case! {
@@ -94,6 +95,9 @@ enametoolong_either_path_test_case!(symlink);
 
 // symlink/04.t
 enoent_comp_test_case!(symlink(Path::new("test"), ~path));
+
+// symlink/10.t
+erofs_new_file_test_case!(symlink(Path::new("test"), ~path));
 
 // symlink/13.t
 efault_either_test_case!(symlink, nix::libc::symlink);

--- a/rust/src/tests/truncate.rs
+++ b/rust/src/tests/truncate.rs
@@ -116,11 +116,11 @@ fn eisdir(ctx: &mut TestContext) {
     assert_eq!(truncate(&path, 0), Err(Errno::EISDIR));
 }
 
+// (f)truncate/10.t
+erofs_named_test_case!(truncate(~path, 123));
+
 // (f)truncate/11.t
 etxtbsy_test_case!(truncate(~path, 123));
-
-// (f)truncate/12.t
-erofs_named_test_case!(truncate(~path, 123));
 
 crate::test_case! {
     /// truncate returns EINVAL if the length argument was less than 0

--- a/rust/src/tests/truncate.rs
+++ b/rust/src/tests/truncate.rs
@@ -15,6 +15,7 @@ use super::errors::{
     enametoolong::{enametoolong_comp_test_case, enametoolong_path_test_case},
     enoent::{enoent_comp_test_case, enoent_named_file_test_case},
     enotdir::enotdir_comp_test_case,
+    erofs::erofs_named_test_case,
     etxtbsy::etxtbsy_test_case,
 };
 
@@ -117,6 +118,9 @@ fn eisdir(ctx: &mut TestContext) {
 
 // (f)truncate/11.t
 etxtbsy_test_case!(truncate(~path, 123));
+
+// (f)truncate/12.t
+erofs_named_test_case!(truncate(~path, 123));
 
 crate::test_case! {
     /// truncate returns EINVAL if the length argument was less than 0

--- a/rust/src/tests/unlink.rs
+++ b/rust/src/tests/unlink.rs
@@ -14,6 +14,7 @@ use super::{
         enametoolong::{enametoolong_comp_test_case, enametoolong_path_test_case},
         enoent::enoent_named_file_test_case,
         enotdir::enotdir_comp_test_case,
+        erofs::erofs_named_test_case,
     },
 };
 
@@ -153,6 +154,9 @@ enoent_named_file_test_case!(unlink);
 
 // unlink/07.t
 eloop_comp_test_case!(unlink);
+
+// unlink/12.t
+erofs_named_test_case!(unlink);
 
 // unlink/13.t
 efault_path_test_case!(unlink, nix::libc::unlink);


### PR DESCRIPTION
The execution of these tests is conditioned to the `allow_erofs` flag, since they require to remount the file system as read-only.