### PR TITLE
Better formatting of results

### DIFF
--- a/rust/src/test.rs
+++ b/rust/src/test.rs
@@ -15,7 +15,6 @@ pub enum TestFn {
 }
 
 /// A single minimal test case.
-#[derive(Clone, Copy)]
 pub struct TestCase {
     pub name: &'static str,
     pub description: &'static str,

--- a/rust/src/test.rs
+++ b/rust/src/test.rs
@@ -8,12 +8,14 @@ pub use crate::flags::*;
 /// Function which indicates if the test should be skipped by returning an error.
 pub type Guard = fn(&Config, &Path) -> Result<(), anyhow::Error>;
 
+#[derive(Clone, Copy)]
 pub enum TestFn {
     Serialized(fn(&mut SerializedTestContext)),
     NonSerialized(fn(&mut TestContext)),
 }
 
 /// A single minimal test case.
+#[derive(Clone, Copy)]
 pub struct TestCase {
     pub name: &'static str,
     pub description: &'static str,


### PR DESCRIPTION
* Align output columns, assuming 80-column terminal
* Use "ok/FAILED" instead of "success/FAILURE", as the standard test harness does.
* Remove the newline after a skipped test
* Strip "pjdfstest::tests::" from all test case names.
* Move a failed test's failure message to a new line.
* Indent a skipped test's skip reasons.

Fixes #140