### PR TITLE
Use a more unique jail name in the securelevel tests

### DIFF
--- a/rust/src/tests/chflags.rs
+++ b/rust/src/tests/chflags.rs
@@ -259,7 +259,7 @@ fn securelevel(ctx: &mut TestContext, ft: FileType) {
     use std::os::unix::ffi::OsStrExt;
 
     let jail = jail::StoppedJail::new("/")
-        .name("pjdfstest_chflags_securelevel")
+        .name(format!("pjdfstest_chflags_securelevel-{}", std::process::id()))
         .param("allow.chflags", jail::param::Value::Int(1))
         .param("securelevel", jail::param::Value::Int(1));
     let jail = jail.start().unwrap();


### PR DESCRIPTION
So that multiple instances of the test suite can run at the same time.

Fixes #166