### PR TITLE
Replace figment with toml

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -59,15 +59,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
-name = "atomic"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,12 +69,6 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
-
-[[package]]
-name = "bytemuck"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
 
 [[package]]
 name = "byteorder"
@@ -205,19 +190,6 @@ name = "fastrand"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
-
-[[package]]
-name = "figment"
-version = "0.10.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
-dependencies = [
- "atomic",
- "serde",
- "toml",
- "uncased",
- "version_check",
-]
 
 [[package]]
 name = "getrandom"
@@ -355,7 +327,6 @@ dependencies = [
  "cfg_aliases",
  "clap",
  "exacl",
- "figment",
  "inventory",
  "jail",
  "nix",
@@ -366,6 +337,7 @@ dependencies = [
  "strum_macros",
  "sysctl",
  "tempfile",
+ "toml",
  "walkdir",
 ]
 
@@ -626,15 +598,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "uncased"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,12 +620,6 @@ name = "uuid"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -19,12 +19,12 @@ strum_macros = "0.27.2"
 anyhow = "1.0.93"
 pastey = "0.2.2"
 clap = { version = "4.5.23", features = ["derive", "wrap_help"] }
-figment = { version = "0.10.6", features = ["toml"] }
 nix = { version = "0.29", features = ["fs", "socket", "mount", "user"] }
 serde = { version = "1.0.214", features = ["derive"] }
 inventory = "0.3.0"
 walkdir = "2.3.2"
 sysctl = "0.6.0"
+toml = { version = "0.8.11", default-features = false, features = [ "parse" ] }
 
 [target.'cfg(target_os = "freebsd")'.dependencies]
 jail = "0.3.1"

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -5,9 +5,12 @@
 //!
 //! The configuration is loaded from a TOML file, which is passed as a command line argument to the test suite.
 
-use std::collections::HashMap;
-use std::collections::HashSet;
-use std::path::PathBuf;
+use std::{
+    collections::{HashMap, HashSet},
+    fs,
+    path::PathBuf,
+    process,
+};
 
 use crate::test::FileFlags;
 use crate::test::FileSystemFeature;
@@ -49,8 +52,10 @@ pub struct SettingsConfig {
     pub naptime: f64,
     /// Allow remounting the file system with different settings during tests
     /// (required for example by the `erofs` tests).
+    #[serde(default)]
     pub allow_remount: bool,
     /// Test cases that are expected to fail
+    #[serde(default)]
     pub expected_failures: HashSet<String>,
 }
 
@@ -72,9 +77,31 @@ const fn default_naptime() -> f64 {
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct Config {
     /// File-system features.
+    #[serde(default)]
     pub features: FeaturesConfig,
     /// File-system specific settings.
+    #[serde(default)]
     pub settings: SettingsConfig,
     /// Dummy authentication configuration.
+    #[serde(default)]
     pub dummy_auth: DummyAuthConfig,
+}
+
+impl Config {
+    pub fn load(path: &PathBuf) -> Self {
+        let r = match fs::read_to_string(path) {
+            Ok(s) => toml::from_str(&s),
+            Err(e) => {
+                eprintln!("Error reading config file: {e}");
+                process::exit(1);
+            }
+        };
+        match r {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("Error reading config file: {e}");
+                process::exit(1);
+            }
+        }
+    }
 }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -29,10 +29,6 @@ use std::{
 
 use clap::Parser;
 use config::Config;
-use figment::{
-    providers::{Format, Serialized, Toml},
-    Figment,
-};
 use nix::{
     sys::stat::{umask, Mode},
     unistd::Uid,
@@ -117,16 +113,11 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let config: Config = {
-        let mut figment = Figment::from(Serialized::defaults(Config::default()));
-        if let Some(path) = args.configuration_file.as_deref() {
-            figment = figment.merge(Toml::file(path))
-        }
-
-        let mut config: Config = figment.extract()?;
-        config.features.secondary_fs = args.secondary_fs;
-        config
-    };
+    let config = args
+        .configuration_file
+        .as_ref()
+        .map(Config::load)
+        .unwrap_or_default();
 
     let path = args
         .path


### PR DESCRIPTION
Figment is intended for hierarchical trees of config files, but that's not really appropriate for pjdfstest.  And it led to surprising behavior, like no error if the config file name on the command line is not found.

Fixes #162