### PR TITLE
Better formatted output

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -161,6 +161,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +363,7 @@ dependencies = [
  "caps",
  "cfg_aliases",
  "clap",
+ "colored",
  "exacl",
  "figment",
  "inventory",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 license = "BSD-2-Clause"
 
 [dependencies]
+colored = "3"
 exacl = "0.12.0"
 tempfile = "3.14.0"
 rand = { version = "0.8.6", features = ["min_const_gen"] }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -28,6 +28,7 @@ use std::{
 };
 
 use clap::Parser;
+use colored::{Color, Colorize};
 use config::Config;
 use figment::{
     providers::{Format, Serialized, Toml},
@@ -98,6 +99,14 @@ struct OverallResult {
 }
 
 impl OverallResult {
+    fn color(&self) -> Color {
+        if self.pass() {
+            Color::Green
+        } else {
+            Color::Red
+        }
+    }
+
     fn pass(&self) -> bool {
         self.fail + self.unexpect_pass == 0
     }
@@ -168,11 +177,16 @@ fn main() -> anyhow::Result<()> {
     let overall_result = run_test_cases(&test_cases, args.verbose, &config, base_dir)?;
 
     println!(
-        "\nTests: {} failed, {} skipped, {} passed, {} expected failures {} total",
-        overall_result.fail + overall_result.unexpect_pass,
+        "\n{}: {} {}, {} {}, {} {}, {} {}, {} total",
+        "Summary".color(overall_result.color()).bold(),
+        (overall_result.fail + overall_result.unexpect_pass),
+        "failed".red().bold(),
         overall_result.skip,
+        "skipped".yellow().bold(),
         overall_result.pass,
+        "passed".green().bold(),
         overall_result.expect_fail,
+        "expected failures".bright_green().bold(),
         overall_result.total()
     );
 
@@ -249,12 +263,12 @@ fn run_test_cases(
         stdout().lock().flush()?;
 
         if should_skip {
-            println!("{:72} skipped", test_case.name);
+            println!("{:72} {}", test_case.name.blue(), "skipped".yellow());
             if verbose && !test_case.description.is_empty() {
                 println!("\t{}", test_case.description);
             }
             for reason in &skip_reasons {
-                println!("\t{}", reason);
+                println!("\t{}", reason.yellow());
             }
             skipped_tests_count += 1;
             continue;
@@ -273,18 +287,29 @@ fn run_test_cases(
             }
         });
 
-        match result {
+        let error_info = match result {
             Ok(_) if !expect_fail => {
-                println!("{:77} ok", test_case.name);
+                println!("{:77} {}", test_case.name.blue(), "ok".green());
                 succeeded_tests_count += 1;
+                None
             }
             Ok(_) => {
-                println!("{:60} PASSED UNEXPECTEDLY", test_case.name);
+                println!(
+                    "{:60} {}",
+                    test_case.name.blue(),
+                    "PASSED UNEXPECTEDLY".red()
+                );
                 unexpected_success_count += 1;
+                None
             }
             Err(_) if expect_fail => {
-                println!("{:61} failed as expected", test_case.name);
+                println!(
+                    "{:61} {}",
+                    test_case.name.blue(),
+                    "failed as expected".green()
+                );
                 expected_fail_count += 1;
+                None
             }
             Err(e) => {
                 let backtrace = BACKTRACE
@@ -299,11 +324,18 @@ fn run_test_cases(
                         _ => "Unknown Source of Error".to_owned(),
                     },
                 };
-                println!("{:73} FAILED\n\t{}", test_case.name, panic_information);
-                if let Some(backtrace) = backtrace {
-                    println!("Backtrace:\n{}", backtrace);
-                }
+                println!("{:73} {}", test_case.name.blue(), "FAILED".red());
                 failed_tests_count += 1;
+                Some((panic_information, backtrace))
+            }
+        };
+        if verbose && !test_case.description.is_empty() {
+            println!("\t{}", test_case.description);
+        }
+        if let Some((panic_information, backtrace)) = error_info {
+            println!("\t{}", panic_information);
+            if let Some(backtrace) = backtrace {
+                println!("Backtrace:\n{}", backtrace);
             }
         }
 


### PR DESCRIPTION
* Use colors
* Print test case descriptions (in verbose mode) on their own line

Use the colored crate instead of owo-colors because the former automatically handles terminal feature an NO_COLOR detection, whereas the latter requires sprinkling ".if_supports_color()" calls everywhere.

Example screenshot:
<img width="827" height="219" alt="Screenshot_2026-05-03_17-35-50" src="https://github.com/user-attachments/assets/f9171c12-ed77-4779-a871-b31921861d98" />
