### PR TITLE
Simplify the assert_uid_gid tests

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -4,3 +4,8 @@
 
 - Fixed the --secondary-fs argument
   ([#181](https://github.com/saidsay-so/pjdfstest/pull/181))
+
+### Changed
+
+- Removed the need for a third user from the config file.
+  ([#180](https://github.com/saidsay-so/pjdfstest/pull/180))

--- a/rust/README.md
+++ b/rust/README.md
@@ -116,21 +116,13 @@ It is also possible to specify other users with the configuration file.
 
 #### FreeBSD
 
-FreeBSD by default has enough builtin users.  But additional ones can be
-created like this:
-
-```bash
-cat <<EOF | adduser -w none -S -f -
-pjdfstest::::::Dummy User for pjdfstest:/nonexistent:/sbin/nologin:
-EOF
-```
+FreeBSD by default has enough builtin users.
 
 #### Linux
 
 ```bash
 cat <<EOF | newusers
 tests:x:::Dummy User for pjdfstest:/:/usr/bin/nologin
-pjdfstest:x:::Dummy User for pjdfstest:/:/usr/bin/nologin
 EOF
 ```
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -61,14 +61,13 @@ allow_remount = false
 # This section allows to modify the mechanism for switching users, which is required by some tests.
 # [dummy_auth]
 # An entry is the name of a user and its associated group.
-# For now, the array requires exactly 3 entries.
+# For now, the array requires exactly 2 entries.
 # Please see the book for more details.
 # entries = [
 #   ["nobody", "nobody"],
 #   nogroup instead for some Linux distros
 #   ["nobody", "nogroup"],
 #   ["tests", "tests"],
-#   ["pjdfstest", "pjdfstest"],
 # ]
 ```
 
@@ -110,13 +109,15 @@ By default, the users (with the same name for the group associated to each of th
 
 - nobody
 - tests
-- pjdfstest
 
 It is also possible to specify other users with the configuration file.
 
 ### Create users
 
 #### FreeBSD
+
+FreeBSD by default has enough builtin users.  But additional ones can be
+created like this:
 
 ```bash
 cat <<EOF | adduser -w none -S -f -

--- a/rust/pjdfstest.toml
+++ b/rust/pjdfstest.toml
@@ -31,12 +31,11 @@ expected_failures = [
 # required by some tests.
 [dummy_auth]
 # An entry is the name of a user and its associated group.
-# For now, the array requires exactly 3 entries.
+# For now, the array requires exactly 2 entries.
 # Please see the book for more details.
  entries = [
    ["nobody", "nobody"],
-#   nogroup instead for some Linux distros
-#   ["nobody", "nogroup"],
+   #nogroup instead for some Linux distros
+   #["nobody", "nogroup"],
    ["tests", "tests"],
-   ["pjdfstest", "pjdfstest"],
 ]

--- a/rust/src/config/auth.rs
+++ b/rust/src/config/auth.rs
@@ -106,7 +106,7 @@ pub struct DummyAuthConfig {
     /// Auth entries, which are composed of a [`User`] and its associated [`Group`].
     /// The user should be part of the associated group.
     /// They are used when a test requires switching to different users.
-    pub entries: [DummyAuthEntry; 3],
+    pub entries: [DummyAuthEntry; 2],
 }
 
 impl Default for DummyAuthConfig {
@@ -119,14 +119,6 @@ impl Default for DummyAuthConfig {
             eprintln!("error: {}: no such group", unobody.gid);
             exit(1);
         });
-        let upjdfstest = User::from_name("pjdfstest").unwrap().unwrap_or_else(|| {
-            eprintln!("error: pjdfstest: no such user");
-            exit(1);
-        });
-        let gpjdfstest = Group::from_gid(upjdfstest.gid).unwrap().unwrap_or_else(|| {
-            eprintln!("error: {}: no such group", upjdfstest.gid);
-            exit(1);
-        });
         let utests = User::from_name("tests").unwrap().unwrap_or_else(|| {
             eprintln!("error: tests: no such user");
             exit(1);
@@ -137,15 +129,9 @@ impl Default for DummyAuthConfig {
         });
         Self {
             entries: [
-                {
-                    DummyAuthEntry {
-                        user: unobody,
-                        group: gnobody,
-                    }
-                },
                 DummyAuthEntry {
-                    user: upjdfstest,
-                    group: gpjdfstest,
+                    user: unobody,
+                    group: gnobody,
                 },
                 DummyAuthEntry {
                     user: utests,

--- a/rust/src/tests/mksyscalls.rs
+++ b/rust/src/tests/mksyscalls.rs
@@ -103,18 +103,17 @@ where
         assert!(filestat.st_gid == egid || filestat.st_gid == dirstat.st_gid);
     }
 
-    let user = User::from_uid(Uid::effective()).unwrap().unwrap();
-    doit(ctx, &user, None, &f);
+    let user0 = User::from_uid(Uid::effective()).unwrap().unwrap();
+    doit(ctx, &user0, None, &f);
 
-    let user = ctx.get_new_user();
+    let user1 = ctx.get_new_user();
     // To check that the entry gid is either parent gid or egid
-    chown(ctx.base_path(), Some(user.uid), Some(user.gid)).unwrap();
+    chown(ctx.base_path(), Some(user1.uid), Some(user1.gid)).unwrap();
 
-    let (other_user, group) = ctx.get_new_entry();
-    doit(ctx, user, Some(group.gid), &f);
+    let (user2, group2) = ctx.get_new_entry();
+    doit(ctx, user1, Some(group2.gid), &f);
 
     chmod(ctx.base_path(), Mode::from_bits_truncate(ALLPERMS)).unwrap();
 
-    let group = ctx.get_new_group();
-    doit(ctx, other_user, Some(group.gid), f);
+    doit(ctx, user2, Some(group2.gid), f);
 }


### PR DESCRIPTION
These tests really don't need 3 users and 3 groups.  They are only using 2 users and 3 groups, but the third group doesn't really add any value. The requirement can be satisified with just 2 users and 2 groups.

Having simplified these tests, remove the third user from the default configuration and the documentation.