### PR TITLE
Fix the --secondary-fs argument

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -1,0 +1,6 @@
+## [unreleased] - ReleaseDate
+
+### Fixed
+
+- Fixed the --secondary-fs argument
+  ([#181](https://github.com/saidsay-so/pjdfstest/pull/181))

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -122,11 +122,14 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let config = args
+    let mut config = args
         .configuration_file
         .as_ref()
         .map(Config::load)
         .unwrap_or_default();
+    if let Some(sfs) = args.secondary_fs {
+        config.features.secondary_fs = Some(sfs);
+    }
 
     let path = args
         .path


### PR DESCRIPTION
It has accidentally been ignored ever since #172

Fixes #179